### PR TITLE
Avoid adding `EventListener`s every frame

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,10 +127,10 @@
         <div class="flexBox" style="margin-top: 1rem">
             <button class="tabButton" id="upgradeTab" onclick="switchBoostTab('upgrades')" style="color: #8080FF; border-color: #0000ff">Upgrades</button>
             <button class="tabButton" id="auto2Tab" onclick="switchBoostTab('auto2')" style="color: #8080FF; border-color: #0000ff; width: 5.5rem">AutoBuyers</button>
-            <button class="tabButton" id="chalTab" style="color: #8080FF; border-color: #0000ff; width: 5.5rem">Challenges</button>
-            <button class="tabButton" id="incrementyTab" style="color: #8080FF; border-color: #0000ff; width: 5.5rem">Incrementy</button>
-            <button class="tabButton" id="hierarchiesTab" style="color: #8080FF; border-color: #0000ff; width: 5.5rem">Hierarchies</button>
-            <button class="tabButton" id="overflowTab" style="color: #8080FF; border-color: #0000ff; width: 5.5rem">Overflow</button>
+            <button class="tabButton" id="chalTab" style="color: #8080FF; border-color: #0000ff; width: 5.5rem" onclick="if(chalTabUnlocked()) {switchBoostTab('chal');}">Challenges</button>
+            <button class="tabButton" id="incrementyTab" style="color: #8080FF; border-color: #0000ff; width: 5.5rem" onclick="if(incrementyTabUnlocked()) {switchBoostTab('incrementy');}">Incrementy</button>
+            <button class="tabButton" id="hierarchiesTab" style="color: #8080FF; border-color: #0000ff; width: 5.5rem" onclick="if(hierarchiesTabUnlocked()) {switchBoostTab('hierarchies');}">Hierarchies</button>
+            <button class="tabButton" id="overflowTab" style="color: #8080FF; border-color: #0000ff; width: 5.5rem" onclick="if(overflowTabUnlocked()) {switchBoostTab('overflow');}">Overflow</button>
         </div>
         <div class="flexBox" id="upgradesSubPage" style="margin-top: 1rem; flex-direction: column">
             <div class="centeredTexts" id="boosterText">boosteeeeeeeee</div>

--- a/src/boosters/boosters.js
+++ b/src/boosters/boosters.js
@@ -194,10 +194,26 @@ function boosterRefund(c=false){
 }
 
 function boosterUnlock(){
-    if(data.boost.total>=6 || data.collapse.hasSluggish[1]){ data.boost.unlocks[0] = true; DOM(`bu0`).style.backgroundColor = '#002480'; DOM('chalTab').addEventListener('click', _=> switchBoostTab('chal')) }
-    if(data.boost.total>=91 || data.collapse.hasSluggish[1]){ data.boost.unlocks[1] = true; DOM(`bu1`).style.backgroundColor = '#002480';  DOM('incrementyTab').addEventListener('click', _=> switchBoostTab('incrementy')) }
-    if(data.boost.total>=325){ data.boost.unlocks[2] = true; DOM(`bu2`).style.backgroundColor = '#002480'; DOM('hierarchiesTab').addEventListener('click', _=> switchBoostTab('hierarchies')) }
-    if(data.boost.total>=465){ data.boost.unlocks[3] = true; DOM(`bu3`).style.backgroundColor = '#002480'; DOM('overflowTab').addEventListener('click', _=> switchBoostTab('overflow')) }
+    if(chalTabUnlocked()){ data.boost.unlocks[0] = true; DOM(`bu0`).style.backgroundColor = '#002480'; }
+    if(incrementyTabUnlocked()){ data.boost.unlocks[1] = true; DOM(`bu1`).style.backgroundColor = '#002480';  }
+    if(hierarchiesTabUnlocked()){ data.boost.unlocks[2] = true; DOM(`bu2`).style.backgroundColor = '#002480'; }
+    if(overflowTabUnlocked()){ data.boost.unlocks[3] = true; DOM(`bu3`).style.backgroundColor = '#002480'; }
+}
+
+function chalTabUnlocked(){
+    return data.boost.total>=6 || data.collapse.hasSluggish[1];
+}
+
+function incrementyTabUnlocked(){
+    return data.boost.total>=91 || data.collapse.hasSluggish[1];
+}
+
+function hierarchiesTabUnlocked(){
+    return data.boost.total>=325;
+}
+
+function overflowTabUnlocked(){
+    return data.boost.total>=465;
 }
 
 function toggleAuto(i){

--- a/src/update.js
+++ b/src/update.js
@@ -22,10 +22,6 @@ const uHTML = {
         DOM('factorBoostButton').style.display = data.boost.times>0 || data.collapse.times>0?'inline-block':'none'
 
         if(data.markup.shifts === 7 || data.chal.active[4]) DOM('dynamicTab').addEventListener('click', _=> switchMarkupTab('dynamic'))
-        if(data.boost.total >= 6) DOM('chalTab').addEventListener('click', _=> switchBoostTab('chal'))
-        if(data.boost.total >= 91) DOM('incrementyTab').addEventListener('click', _=> switchBoostTab('incrementy'))
-        if(data.boost.total >= 325) DOM('hierarchiesTab').addEventListener('click', _=> switchBoostTab('hierarchies'))
-        if(data.boost.total >= 465) DOM('overflowTab').addEventListener('click', _=> switchBoostTab('overflow'))
 
         DOM('bp2Description').innerText = data.overflow.thirdEffect ? 'Dividing Decrementy Gain by ' : 'Multiplying Decrementy Gain by '
         DOM('progressBarContainer').style.display = data.sToggles[6] ? 'flex' : 'none'


### PR DESCRIPTION
Fixes the memory leak from #8.

I moved the conditions for the tabs into their own functions, so that the event listeners will stay in sync with `boosterUnlock`. There was a lot of overlap with the `isTabUnlocked` function, but the conditions weren't exactly the same, so that could probably be cleaned up in the future.

With these changes I was able to leave the game running overnight with no performance issues.