### PR TITLE
Fixes related to version upgrade to 0.1.2

### DIFF
--- a/src/boosters/boosters.js
+++ b/src/boosters/boosters.js
@@ -92,7 +92,7 @@ const chargedBUPDesc = ['Each Factor\'s effect is Quadrupled', 'Boost OP gain by
 
 let bup0Effect = () => data.boost.hasBUP[0] ? data.boost.isCharged[0] ? 4 : 2 : 1
 let bup1Effect = () => data.boost.hasBUP[1] ? data.boost.isCharged[1] ? 500 : 5 : 1
-let bup2Effect = () => data.chal.active[6] ? 10 : data.boost.isCharged[2] ? 4 : 5
+let bup2Effect = () => data.chal.active[6] ? 10 - data.markup.shifts : data.boost.isCharged[2] ? 4 : 5
 let bup3Effect = () => data.boost.hasBUP[3] ? Math.max(Math.pow(2, data.chal.completions[4]), 1) : 1
 function bup48Effect(){
     if(data.boost.isCharged[5] && data.boost.isCharged[10] && data.hierarchies.hasUpgrade[4]) return Math.sqrt(factorEffect(6))**2
@@ -101,10 +101,10 @@ function bup48Effect(){
 }
 let bup5Effect = () => data.boost.hasBUP[6] ? data.boost.isCharged[6] ? Math.max(Math.sqrt(data.boost.total)*3, 1) : Math.max(Math.sqrt(data.boost.total), 1) : 1
 let bup6Effect = () => data.boost.hasBUP[7] ? data.boost.isCharged[7] ? 100 : 10 : 0
-let bup7Effect = () => data.boost.hasBUP[8] ? data.boost.isCharged[8] ? Math.max(1,(-data.ord.base + 6)) : data.ord.base-2 : 1
-let bup9Effect = () => data.boost.hasBUP[10] ? data.boost.isCharged[10] ? Math.max(20*(-data.ord.base+11)*getOverflowEffect(1), 1) : 20*getOverflowEffect(1) : 1
-let bup10Effect = () => data.boost.hasBUP[11] ? data.boost.isCharged[11] ? 4 : 3 : 0
-let bup11Effect = () => data.boost.hasBUP[12] ? Math.max(Math.log2(data.boost.amt), 1) : 1
+let bup7Effect = () => data.boost.hasBUP[8] ? data.boost.isCharged[8] ? Math.max(1,(-data.ord.base + 6)) : Math.max(1,data.ord.base-2) : 1
+let bup9Effect = () => data.boost.hasBUP[11] ? data.boost.isCharged[11] ? Math.max(20*(-data.ord.base+11)*getOverflowEffect(1), 1) : 20*getOverflowEffect(1) : 1
+let bup10Effect = () => data.boost.hasBUP[12] ? data.boost.isCharged[12] ? 4 : 3 : 0
+let bup11Effect = () => data.boost.hasBUP[13] ? Math.max(Math.log2(data.boost.amt), 1) : 1
 
 let sBUP0Effect = () => data.boost.hasBUP[4] ? data.boost.isCharged[4] ? Math.floor((data.darkness.totalDrains+getTotalDUPs())/10)
     : Math.floor(getTotalDUPs()/10)
@@ -225,15 +225,16 @@ function buyBUP(i, bottomRow){
 function boosterRefund(c=false){
     respecCharge(c)
 
-    let indexes = []
+    //let indexes = []
     for (let i = 0; i < data.boost.hasBUP.length; i++) {
-        if (data.boost.hasBUP[i]) indexes.push(i)
+        //if (data.boost.hasBUP[i]) indexes.push(i)
         data.boost.hasBUP[i] = false
         DOM(`bup${i}`).style.backgroundColor = 'black'
     }
-    for (let i = 0; i < indexes.length; i++){
+    /*for (let i = 0; i < indexes.length; i++){
         data.boost.amt += bupCosts[indexes[i]]
-    }
+    }*/
+    data.boost.amt = data.boost.total
     c?boosterReset():chalExit()
 }
 

--- a/src/boosters/incrementy.js
+++ b/src/boosters/incrementy.js
@@ -131,4 +131,9 @@ function sacrificeIncrementy(){
     }
 }
 
-let chargeReq = () => (10**(6+((data.incrementy.totalCharge+data.darkness.sacrificedCharge)*(2+Math.floor((data.incrementy.totalCharge+data.darkness.sacrificedCharge)/12)))))/hierarchyData[1].effect()
+//let chargeReq = () => (10**(6+((data.incrementy.totalCharge+data.darkness.sacrificedCharge)*(2+Math.floor((data.incrementy.totalCharge+data.darkness.sacrificedCharge)/12)))))/hierarchyData[1].effect()
+function chargeReq() {
+    let chargeExp = 6+((data.incrementy.totalCharge+data.darkness.sacrificedCharge)*(2+Math.floor((data.incrementy.totalCharge+data.darkness.sacrificedCharge)/12)));
+    chargeExp -= Math.log10(hierarchyData[1].effect());
+    return 10**chargeExp;
+}

--- a/src/data.js
+++ b/src/data.js
@@ -79,11 +79,20 @@ function fixOldSaves(){
     let extra = false
 
     //v0.1.1 => v0.1.2
-    if(data.collapse.hasSluggish.length === 6) data.collapse.hasSluggish.pop()
-    if(data.loadedVersion !== "0.1.2" && data.collapse.hasSluggish[3]){
-        data.collapse.hasSluggish[3] = false
-        data.collapse.hasSluggish[4] = false
-        data.loadedVersion = "0.1.2"
+    if(data.loadedVersion < "0.1.2" || data.loadedVersion === "null") {
+        data.hierarchies = data.hierachies;
+        for (let i = 7; i >= 5; i--) data.hierarchies.hasUpgrade[i] = data.hierarchies.hasUpgrade[i-2];
+        for (let i = 3; i < 5; i++) data.hierarchies.hasUpgrade[i] = false;
+        for (let i = 13; i >= 10; i--) { data.boost.hasBUP[i] = data.boost.hasBUP[i-2]; data.boost.isCharged[i] = data.boost.isCharged[i-2]; }
+        data.boost.hasBUP[9] = false; data.boost.isCharged[9] = false;
+        for (let i = 8; i >= 5; i--) { data.boost.hasBUP[i] = data.boost.hasBUP[i-1]; data.boost.isCharged[i] = data.boost.isCharged[i-1]; }
+        data.boost.hasBUP[4] = false; data.boost.isCharged[4] = false;
+        if(data.collapse.hasSluggish.length === 6) data.collapse.hasSluggish.pop();
+        if(data.collapse.hasSluggish[3]){
+            data.collapse.hasSluggish[3] = false
+            data.collapse.hasSluggish[4] = false
+        }
+        extra = true
     }
     //v0.1 => v0.1.1
     if(data.loadedVersion === "0.0.6") data.loadedVersion = "0.1" //Forgot to do this, thankfully I caught it in time
@@ -115,11 +124,10 @@ function fixOldSaves(){
 }
 function fixOldSavesP2(){
     //v0.1 => v0.1.1
-    if(data.loadedVersion === "0.1"){
+    if(data.loadedVersion < "0.1.1" || data.loadedVersion === "null"){
         data.incrementy.charge += data.darkness.sacrificedCharge
         data.incrementy.totalCharge += data.darkness.sacrificedCharge
         resetDarkness(true)
-        data.loadedVersion = "0.1.1"
     }
 
     //v0.0.5 => v0.0.6
@@ -134,6 +142,8 @@ function fixOldSavesP2(){
             data.boost.amt = 465
         }
     }
+
+    data.loadedVersion = "0.1.2"
 }
 function exportSave(){
     try {

--- a/src/etc/progressBar.js
+++ b/src/etc/progressBar.js
@@ -58,14 +58,14 @@ function getTargetOrdinal() {
 function getBarPercent(){
     if((!data.ord.isPsi) && !inNonPsiChallenge()) return 0
     if (data.ord.isPsi && inNonPsiChallenge()) return 100
-    return data.ord.ordinal / getTargetOrdinal() * 100
+    return Math.min(100, data.ord.ordinal / getTargetOrdinal() * 100)
 }
 function getTimeEstimate(){
     if((!data.ord.isPsi) && !inNonPsiChallenge()) return "Unknown... "
     if (data.ord.isPsi && inNonPsiChallenge()) return "0s"
     if(boostReq()===data.ord.ordinal)return "0s"
     let autoSpeed = (data.ord.isPsi ? t2Auto() : (data.autoLevels[0]+extraT1())*t1Auto()*(data.chal.active[4] ? (1/data.dy.level) : data.dy.level) / data.chal.decrementy.toNumber())
-    return formatTime((getTargetOrdinal()-data.ord.ordinal)/autoSpeed)
+    return formatTime(Math.max((getTargetOrdinal()-data.ord.ordinal)/autoSpeed, 0))
 }
 function updateProgressBar(){
     DOM("progressBar").style.width = Math.min(100, getBarPercent()) + "%"

--- a/src/etc/tick.js
+++ b/src/etc/tick.js
@@ -26,11 +26,13 @@ function tick(diff){
         successor(timesToLoop[0]/1000)
         timesToLoop[0] -= Math.floor(timesToLoop[0]/1000)*1000
     }
+    if(isNaN(timesToLoop[0])) timesToLoop[0] = 0
 
     if(Math.floor(timesToLoop[1]/1000) >= 1){
         maximize()
         timesToLoop[1] -= Math.floor(timesToLoop[1]/1000)*1000
     }
+    if(isNaN(timesToLoop[1])) timesToLoop[1] = 0
 
     // Automation Tier 2
     // BuyMax Autobuyer

--- a/src/internal/FormatOrd.js
+++ b/src/internal/FormatOrd.js
@@ -85,6 +85,7 @@ function displayOrd(ord,over,base,trim = data.ord.trim) {
 }
 
 function displayHierarchyOrd(ord,over,base,trim = data.ord.trim) {
+    if (ord === Infinity) return data.gword ? "<img src='https://cdn.discordapp.com/emojis/967188082434662470.webp?size=24'>" : "Ω"
     ord = Math.floor(ord)
     over = Math.floor(over)
     if(trim <= 0) return `...`

--- a/src/internal/FormatOrd.js
+++ b/src/internal/FormatOrd.js
@@ -97,6 +97,8 @@ function displayHierarchyOrd(ord,over,base,trim = data.ord.trim) {
     if (amount > 1) finalOutput += amount
     const firstAmount = amount*magnitudeAmount
     if(ord-firstAmount > 0) finalOutput += "+" + displayHierarchyOrd(ord-firstAmount, over, base, trim - 1)
+    if(data.gword) finalOutput = finalOutput.replaceAll("&omega;","<img src='https://cdn.discordapp.com/emojis/853002327362895882.webp?size=24'>")
+                                            .replaceAll("ω","<img src='https://cdn.discordapp.com/emojis/853002327362895882.webp?size=24'>")
     return finalOutput
 }
 
@@ -117,8 +119,16 @@ function displayHierarchyOrd(ord,over,base,trim = data.ord.trim) {
 
 function displayPsiOrd(ord, trim) {
     ord = Math.floor(ord)
-    if(ord == BHO_VALUE) return "&psi;(Ω<sub>2</sub>)"
-
+    if(ord == BHO_VALUE) {
+        let finalOutput = "&psi;(Ω<sub>2</sub>)"
+        if(data.gword) finalOutput=finalOutput
+            .replaceAll("Ω","<img src='https://cdn.discordapp.com/emojis/967188082434662470.webp?size=24'>")
+        return `${finalOutput}`
+    }
+    let maxOrdMarks = (3**(ordMarks.length-1))*4
+    if(maxOrdMarks < Infinity && new Decimal(ord).gt(new Decimal(maxOrdMarks.toString()))) {
+        return displayPsiOrd(maxOrdMarks) + "x" + format(ord/Number(maxOrdMarks),2)
+    }
     if(ord === 0) return ""
     if(trim <= 0) return "..."
     if(ord < 4) return extraOrdMarks[ord]

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ function mainLoop() {
     let uDiff = diff/1000
 
     if(data.dy.gain > 0 && data.dy.level < data.dy.cap) data.dy.level = Math.min(data.dy.cap, data.dy.level+uDiff*dyGain())
-    if(data.boost.hasBUP[10]) data.markup.powers += bup9Effect()*uDiff
+    if(data.boost.hasBUP[11]) data.markup.powers += bup9Effect()*uDiff
 
     if(data.chal.active[7]) data.chal.decrementy = data.chal.decrementy.plus(decrementyGain(data.chal.decrementy.times(50)).times(uDiff))
 


### PR DESCRIPTION
- critical fixes related to updating old save files
- critical fixes to booster upgrade and hierarchy index-related bugs
- make hierarchy base reduction from booster upgrade 1x5 be effective
- other hierarchy fixes (event listeners and FGH/SGH cost types)
- other bug fixes related to NaN and infinity values in autoclicker speeds, charge costs and hierarchy ord display
- gwaify hierarchy ordinals and BHO, add multiplier above ordMarks cap