### PR TITLE
fix hierarchies successors stuck bug + hierarchies upgrades UI bug + QoL to temporarily turn off factor boost autoprestiger if one can afford SM2

### DIFF
--- a/src/boosters/boosters.js
+++ b/src/boosters/boosters.js
@@ -131,7 +131,7 @@ function updateBoostersHTML(){
     //DOM('bup7').innerText = `${data.boost.isCharged[7]?chargedBUPDesc[7]:bupDesc[7]}\n[${format(bup7Effect())}x]\n${data.boost.isCharged[7]?'':bupCosts[7]} Boosters`
     //DOM('bup11').innerText = `${data.boost.isCharged[11]?chargedBUPDesc[11]:bupDesc[11]}\n[${format(bup11Effect())}x]\n${data.boost.isCharged[11]?'':bupCosts[11]} Boosters`
     for (let i = 0; i < data.autoStatus.enabled.length; i++) {
-        DOM(`t2AutoText${i}`).innerHTML = `Your <span style="color: #80ceff">${autoDisplayNames[i]} AutoBuyer</span> is clicking the ${autoNames[i]} button${i === 3 || i === 4 ? 's' : ''} <span style="color: #8080FF">${i < 2 ? format(t2Auto()) : 1} times/second</span>${autoRequirements[i]}`
+        DOM(`t2AutoText${i}`).innerHTML = `Your <span style="color: #80ceff">${autoDisplayNames[i]} AutoBuyer</span> is clicking the ${autoNames[i]} button${i === 3 || i === 4 ? 's' : ''} <span style="color: #8080FF">${i < 2 ? format(t2Auto()) : 20} times/second</span>${autoRequirements[i]}`
         DOM(`auto${i+2}`).innerText = data.boost.hasBUP[autoUps[i]] || i > 1 ?`${autoDisplayNames[i]} AutoBuyer: ${boolToReadable(data.autoStatus.enabled[i], 'EDL')}`:`${autoDisplayNames[i]} AutoBuyer: LOCKED`
 
     }
@@ -188,6 +188,7 @@ function boost(f=false, auto=false){
     }
 
     let bulkBoostAmt = getBulkBoostAmt();
+    if (auto && data.boost.times < 2 && !hasSluggish[4]) bulkBoostAmt = Math.min(2 - data.boost.times, bulkBoostAmt) // do not automatically boost past SM2
     for(let i=1;i<=bulkBoostAmt;i++) {
         data.boost.amt += data.boost.times+1
         data.boost.total += data.boost.times+1

--- a/src/boosters/hierarchies.js
+++ b/src/boosters/hierarchies.js
@@ -121,7 +121,7 @@ function increaseHierarchies(diff){
     for (let i = 0; i < data.hierarchies.ords.length; i++) {
         let n = hierarchyData[i].gain()*diff/1000
         // Successor
-        if (data.hierarchies.ords[i].ord % hierarchyData[i].base() === hierarchyData[i].base() - 1) data.hierarchies.ords[i].over+=n
+        if (data.hierarchies.ords[i].ord % hierarchyData[i].base() === hierarchyData[i].base() - 1 && data.hierarchies.ords[i].ord < Number.MAX_SAFE_INTEGER) data.hierarchies.ords[i].over+=n
         else data.hierarchies.ords[i].ord+=n
 
         //Maximize

--- a/src/boosters/hierarchies.js
+++ b/src/boosters/hierarchies.js
@@ -14,7 +14,6 @@ function updateHBBuyableHTML(i){
     const cost = i < 3 ? 'FGH' : 'SGH'
     const ord = i < 3 ? 0 : 1
 
-
     el.innerHTML = i == 2 || i==5 ? `${hbData[i].text} (${formatWhole(data.hierarchies.rebuyableAmt[i])})<br>${format(hbData[i].cost())} Incrementy<br>Currently: ${format(hbData[i].effect())}x`
     : `${hbData[i].text} (${formatWhole(data.hierarchies.rebuyableAmt[i])})<br>${displayHierarchyOrd(hbData[i].cost(), 0, 10/*hierarchyData[ord].base()*/, 1)} ${cost}<br>Currently: ${format(hbData[i].effect())}x`
 }
@@ -23,8 +22,10 @@ function updateHUPHTML(i){
     const cost = i < 5 ? 'FGH' : 'SGH'
     const ord = i < 5 ? 0 : 1
 
-
-    el.innerHTML = `${hupData[i].text}<br>${displayHierarchyOrd(hupData[i].cost, 0, 10/*hierarchyData[ord].base*/, 1)} ${cost}<br><font color='#424242'><b>Bought!</b></font>`
+    el.innerHTML = `${hupData[i].text}<br>${displayHierarchyOrd(hupData[i].cost, 0, 10/*hierarchyData[ord].base*/, 1)} ${cost}<br>`
+    if (data.hierarchies.hasUpgrade[i]) {
+        el.innerHTML += `<font color='#424242'><b>Bought!</b></font>`
+    }
 }
 
 function initHierarchies(){

--- a/src/collapse/collapse.js
+++ b/src/collapse/collapse.js
@@ -23,7 +23,7 @@ function updateCollapseHTML(){
 }
 function updateAutoPrestigeHTML(){
     for (let i = 0; i < data.collapse.apEnabled.length; i++) {
-        DOM(`t3AutoText${i}`).innerHTML = `Your <span style='color: #20da45'>${apData[i].name} AutoPrestiger</span> is clicking the ${apData[i].button} button${apData[i].plural ? 's' : ''} <span style='color: #2da000'>1 times/second</span> ${apData[i].hasReq ? `, but only if ${apData[i].requirement}` : ''}`
+        DOM(`t3AutoText${i}`).innerHTML = `Your <span style='color: #20da45'>${apData[i].name} AutoPrestiger</span> is clicking the ${apData[i].button} button${apData[i].plural ? 's' : ''} <span style='color: #2da000'>20 times/second</span> ${apData[i].hasReq ? `, but only if ${apData[i].requirement}` : ''}`
         DOM(`t3AutoToggle${i}`).innerText = `${apData[i].name} AutoPrestiger: ${boolToReadable(data.collapse.apEnabled[i], 'EDL')}`
     }
 }
@@ -191,7 +191,7 @@ let sluggishData = [
 ]
 let apData = [
     {name: "Factor Shift", button: "Shift", requirement: "", hasReq: false, plural: false},
-    {name: "Factor Boost", button: "Boost", requirement: "", hasReq: false, plural: false},
+    {name: "Factor Boost", button: "Boost", requirement: "you can\'t get a Sluggish Milestone", hasReq: true, plural: false},
 ]
 
 function collapse(first = false){

--- a/src/etc/tick.js
+++ b/src/etc/tick.js
@@ -58,8 +58,10 @@ function tick(diff){
     }
 
     // Automation Tier 3
+    let inSluggish = false
+    if (data.boost.times === 2 && !hasSluggish[4]) inSluggish = true
     if(data.collapse.hasSluggish[3] && data.collapse.apEnabled[0] && data.ord.base > 3) factorShift()
-    if(data.collapse.hasSluggish[3] && data.collapse.apEnabled[1] && data.boost.times < boostTimesLimit) boost(false, true)
+    if(data.collapse.hasSluggish[3] && data.collapse.apEnabled[1] && data.boost.times < boostTimesLimit && !inSluggish) boost(false, true)
 
     // Increase Hierarchies
     if(data.boost.unlocks[2]) increaseHierarchies(diff)


### PR DESCRIPTION
do not automatically boost past FB2 if one doesn't have SM2 yet and can afford it at current collapse (+ update descriptions for this as well as to reflect the actual speed that the autoprestigers + new autobuyers work every tick = 20 times/second instead of 1 times/second)