### PR TITLE
Use indirect eval

### DIFF
--- a/src/ordinal/ordinal.js
+++ b/src/ordinal/ordinal.js
@@ -34,14 +34,14 @@ function numberFromOrdinal(string, base) {
 
         if(noTrailing.charAt(noTrailing.length-6) === '.'){ // Rare Edge Case
             const noTrailing2 = noTrailing.substring(0, noTrailing.length-6)
-            return eval(noTrailing2)
+            return eval?.(noTrailing2)
         }
 
-        return eval(noTrailing)
+        return eval?.(noTrailing)
     }
 
     if(secondary.charAt(secondary.length-6) === '.'){ // Rare Edge Case
         const noTrailing = secondary.substring(0, secondary.length-6)
-        return eval(noTrailing)
+        return eval?.(noTrailing)
     }
 }


### PR DESCRIPTION
Direct eval is bad for performance because the evaluated code string has access to variables and functions defined in the surrounding scope. By just using indirect eval, we eliminate that performance hit, by forcing the code to run in the global scope, with a six characters change. Free optimization I guess.

I thought about using the `new Function()` constructor, but we do not need to pass any local variables to the evaluated code, so I went with indirect eval instead.