### PR TITLE
Fix issues related to ordinals and Hardy value display

### DIFF
--- a/src/boosters/boosters.js
+++ b/src/boosters/boosters.js
@@ -224,6 +224,12 @@ function boostReq(n = data.boost.times){
     let scaling = n < 30 ? 1 : Math.floor(100*(n/15))
     return n < 33 ? D(3 ** (n+1) * 4 * 10 * scaling) : D(BHO_VALUE)
 }
+function displayBoostReq(n = data.boost.times){
+    if (n < 33) return displayPsiOrd(boostReq(n), 3)
+    if (n < ordMarks.length - 7) return ordMarks[n+7].replace(/x/, '').replace(/y/, 'ω')
+    if (n <= ordMarksXStart[ordMarksXStart.length-1] - 7) return infiniteOrdMarks(n+7).replace(/x/, '').replace(/y/, 'ω')
+    return infiniteOrdMarks(ordMarksXStart[ordMarksXStart.length-1])+'x'+format(Decimal.pow(3,n-ordMarksXStart[ordMarksXStart.length-1]+7))
+}
 //Credit to ryanleonels
 let boostLimit = () => (data.collapse.times === 0) ? 33 : Infinity;
 function getBulkBoostAmt(){

--- a/src/boosters/boosters.js
+++ b/src/boosters/boosters.js
@@ -144,7 +144,7 @@ function updateBoostersHTML(){
     DOM("hierarchiesTab").innerText = data.boost.unlocks[2]?'Hierarchies':'???'
     DOM("overflowTab").innerText = data.boost.unlocks[3]?'Overflow':'???'
 
-    if(data.chal.active[7]) updateHeaderHTML()
+    if(data.chal.active[6] || data.chal.active[7]) updateHeaderHTML()
 }
 
 function updateHeaderHTML(){
@@ -152,7 +152,7 @@ function updateHeaderHTML(){
     el.style.display = data.chal.active.includes(true) || data.baseless.baseless || inAnyPurification() ? 'block' : 'none'
     el.innerText = inAnyPurification() ? `The ${purificationData[data.omega.whichPurification].alt} will be Purified`
         : data.baseless.baseless ? `You are in the ${baselessNames[data.baseless.mode]} Realm`
-        : data.chal.active[7] ? `You are in Challenge 8 and there is ${format(data.chal.decrementy)} Decrementy` : `You are in Challenge ${data.chal.html+1}`
+        : data.chal.active[7] ? `You are in Challenge 8 and there is ${format(data.chal.decrementy)} Decrementy and ${Math.max(1000-data.successorClicks,0)} clicks left` : `You are in Challenge ${data.chal.html+1}` + (data.chal.active[6] ? ` and there is ${Math.max(1000-data.successorClicks,0)} clicks left` : "")
 }
 
 function updateAllBUPHTML(){

--- a/src/boosters/boosters.js
+++ b/src/boosters/boosters.js
@@ -224,12 +224,6 @@ function boostReq(n = data.boost.times){
     let scaling = n < 30 ? 1 : Math.floor(100*(n/15))
     return n < 33 ? D(3 ** (n+1) * 4 * 10 * scaling) : D(BHO_VALUE)
 }
-function displayBoostReq(n = data.boost.times){
-    if (n < 33) return displayPsiOrd(boostReq(n), 3)
-    if (n < ordMarks.length - 7) return ordMarks[n+7].replace(/x/, '').replace(/y/, 'ω')
-    if (n <= ordMarksXStart[ordMarksXStart.length-1] - 7) return infiniteOrdMarks(n+7).replace(/x/, '').replace(/y/, 'ω')
-    return infiniteOrdMarks(ordMarksXStart[ordMarksXStart.length-1])+'x'+format(Decimal.pow(3,n-ordMarksXStart[ordMarksXStart.length-1]+7))
-}
 //Credit to ryanleonels
 let boostLimit = () => (data.collapse.times === 0) ? 33 : Infinity;
 function getBulkBoostAmt(){

--- a/src/boosters/boosters.js
+++ b/src/boosters/boosters.js
@@ -215,6 +215,9 @@ function boost(f=false, auto=false, hotkey=false){
 
         if(data.boost.times === 30 && data.collapse.times === 0) createAlert('Congratulations!', `You've Factor Boosted 30 times! Something new is right around the corner, but these last 4 Boosts will be the hardest...`, 'Onwards!')
     }*/
+    data.boost.amt = Math.min(data.boost.amt, Number.MAX_VALUE)
+    data.boost.total = Math.min(data.boost.total, Number.MAX_VALUE)
+    data.boost.times = Math.min(data.boost.times, Number.MAX_VALUE)
     boosterUnlock()
     boosterReset()
 }
@@ -227,7 +230,7 @@ function boostReq(n = data.boost.times){
 //Credit to ryanleonels
 let boostLimit = () => (data.collapse.times === 0) ? 33 : Infinity;
 function getBulkBoostAmt(){
-    if (!data.sToggles[7] || !data.ord.isPsi || data.ord.ordinal.lte(boostReq())) return 1
+    if (!data.sToggles[7] || !data.ord.isPsi || data.ord.ordinal.lte(boostReq()) || data.boost.times >= Number.MAX_VALUE) return 1
     let maxBoost = data.boost.times
     while (data.ord.ordinal.gte(boostReq(maxBoost)) && maxBoost < boostLimit()) {
         maxBoost++
@@ -236,7 +239,7 @@ function getBulkBoostAmt(){
             break
         }
     }
-    return Math.max(maxBoost - data.boost.times, 1)
+    return Math.min(Math.max(maxBoost - data.boost.times, 1), Number.MAX_VALUE)
     //return Math.round(Math.log(data.ord.ordinal/40)/Math.log(3)) - data.boost.times
 }
 //End credit

--- a/src/collapse/collapse.js
+++ b/src/collapse/collapse.js
@@ -3,9 +3,9 @@ function updateCollapseHTML(){
     DOM(`collapseButton`).innerText = `Collapse for ${format(cardinalGain())} Cardinals (C)`
 
     for (let i = 0; i < data.collapse.hasCUP.length-1; i++) {
-        if(data.collapse.hasCUP[i]) DOM(`cup${i}`).innerText = `${cupData[i].text}\n\nCurrently: ${i===1?'^':''}${i===1 ? format(cupData[i].effect()+drainEffect(i)) : format(cupData[i].effect()*drainEffect(i))}${i!==1?'x':''}`
+        if(data.collapse.hasCUP[i]) DOM(`cup${i}`).innerText = `${cupData[i].text}\n\nCurrently: ${i===1?'^':''}${format(cupEffect(i))}${i!==1?'x':''}`
     }
-    if(data.collapse.hasCUP[7]) DOM(`cup7`).innerText = `${cupData[7].text}\n\nCurrently: ${format(cupData[7].effect())}%`
+    if(data.collapse.hasCUP[7]) DOM(`cup7`).innerText = `${cupData[7].text}\n\nCurrently: ${format(cupEffect(7))}%`
 
     DOM("collapseButton").style.color = data.ord.isPsi && data.ord.ordinal.gte(BHO_VALUE) ? '#fff480' : '#20da45'
 
@@ -159,8 +159,8 @@ let alephEffect = (i) => data.collapse.alephs[i] > 0 && (!inPurification(1) || i
     ? alephData[i].effect()*(i !== 8 ? cupEffect(6) : 1)
     : 1
 let cupEffect = (i) => data.collapse.hasCUP[i] ?
-    i===1 ? Math.max(cupData[i].effect()+drain1Effect(), 1)
-    : Math.max(cupData[i].effect()*drainEffect(i), 1)
+    i===1 ? Math.min(Math.max(cupData[i].effect()+drain1Effect(), 1), Number.MAX_VALUE)
+    : Math.min(Math.max(cupData[i].effect()*drainEffect(i), 1), Number.MAX_VALUE)
     : 1
 
 let drain1Effect = () =>
@@ -196,7 +196,7 @@ let cupData = [
     {text: "Square AutoClicker speeds", cost: 27, effect: ()=> 2},
     {text: "Challenges 1-7 provide greatly reduced boosts when at zero completions", cost: 81, effect: ()=> 0.2*8},
     {text: "Ordinal Powers boost AutoBuyers and AutoClickers", cost: 243, effect: ()=> Math.pow(data.markup.powers, 1/256)},
-    {text: "Incrementy boosts its own gain", cost: 2187, effect: ()=> Math.min(Math.max(1, Decimal.log10(data.incrementy.amt.plus(1)).toNumber())*purificationEffect(3), Number.MAX_VALUE)}, //TODO: Add a safety function
+    {text: "Incrementy boosts its own gain", cost: 2187, effect: ()=> Math.min(Decimal.max(1, Decimal.log10(data.incrementy.amt.plus(1))).mul(purificationEffect(3)).toNumber(), Number.MAX_VALUE)}, //TODO: Add a safety function
     {text: "Unlock a 3rd Overcharge Effect and boost Overcharge's 1st Effect", cost: 196608, effect: ()=> 3},
     {text: "Unspent Cardinals boost Alephs", cost: 3e9, effect: ()=> Math.max(1, Math.log2(data.collapse.cardinals)*getAOMEffect(3))},
     {text: "Gain a percent of best Cardinals gained on Collapse every second", cost: 4e13, effect: ()=> getAOREffect(7)},

--- a/src/etc/progressBar.js
+++ b/src/etc/progressBar.js
@@ -66,7 +66,14 @@ function getTimeEstimate(){
     if (data.ord.isPsi && inNonPsiChallenge()) return "0s"
 
     if(getTargetOrdinal().lt(data.ord.ordinal))return "0s"
-    let autoSpeed = Decimal.max(1, (data.ord.isPsi ? t2Auto() : D(data.autoLevels[0]+extraT1()*t1Auto()*(data.chal.active[4] ? (1/data.dy.level) : data.dy.level)).div(data.chal.decrementy)))
+    //let autoSpeed = Decimal.max(1, (data.ord.isPsi ? t2Auto() : D(data.autoLevels[0]+extraT1()*t1Auto()*(data.chal.active[4] ? (1/data.dy.level) : data.dy.level)).div(data.chal.decrementy)))
+    let succSpeed = !data.chal.active[4]
+        ? D(data.autoLevels[0]).add(extraT1()).mul(t1Auto()).mul(data.dy.level).div(data.chal.decrementy)
+        : D(data.autoLevels[0]).add(extraT1()).mul(t1Auto()).div(data.dy.level).div(data.chal.decrementy)
+    let maxSpeed = !data.chal.active[4]
+        ? D(data.autoLevels[1]).add(extraT1()).mul(t1Auto()).mul(data.dy.level).div(data.chal.decrementy)
+        : D(data.autoLevels[1]).add(extraT1()).mul(t1Auto()).div(data.dy.level).div(data.chal.decrementy)
+    let autoSpeed = Decimal.max(1, Decimal.min(succSpeed, maxSpeed.mul(data.ord.base)))
     return formatTime(Decimal.max((getTargetOrdinal().sub(data.ord.ordinal)).div(autoSpeed), D(0)))
 }
 function updateProgressBar(){

--- a/src/etc/progressBar.js
+++ b/src/etc/progressBar.js
@@ -66,14 +66,16 @@ function getTimeEstimate(){
     if (data.ord.isPsi && inNonPsiChallenge()) return "0s"
 
     if(getTargetOrdinal().lt(data.ord.ordinal))return "0s"
-    //let autoSpeed = Decimal.max(1, (data.ord.isPsi ? t2Auto() : D(data.autoLevels[0]+extraT1()*t1Auto()*(data.chal.active[4] ? (1/data.dy.level) : data.dy.level)).div(data.chal.decrementy)))
-    let succSpeed = !data.chal.active[4]
-        ? D(data.autoLevels[0]).add(extraT1()).mul(t1Auto()).mul(data.dy.level).div(data.chal.decrementy)
-        : D(data.autoLevels[0]).add(extraT1()).mul(t1Auto()).div(data.dy.level).div(data.chal.decrementy)
-    let maxSpeed = !data.chal.active[4]
-        ? D(data.autoLevels[1]).add(extraT1()).mul(t1Auto()).mul(data.dy.level).div(data.chal.decrementy)
-        : D(data.autoLevels[1]).add(extraT1()).mul(t1Auto()).div(data.dy.level).div(data.chal.decrementy)
-    let autoSpeed = Decimal.max(1, Decimal.min(succSpeed, maxSpeed.mul(data.ord.base)))
+    let autoSpeed = Decimal.max(1, (data.ord.isPsi ? t2Auto() : D(data.autoLevels[0]+extraT1()*t1Auto()*(data.chal.active[4] ? (1/data.dy.level) : data.dy.level)).div(data.chal.decrementy)))
+    if (!data.ord.isPsi) {
+        let succSpeed = !data.chal.active[4]
+            ? D(data.autoLevels[0]).add(extraT1()).mul(t1Auto()).mul(data.dy.level).div(data.chal.decrementy)
+            : D(data.autoLevels[0]).add(extraT1()).mul(t1Auto()).div(data.dy.level).div(data.chal.decrementy)
+        let maxSpeed = !data.chal.active[4]
+            ? D(data.autoLevels[1]).add(extraT1()).mul(t1Auto()).mul(data.dy.level).div(data.chal.decrementy)
+            : D(data.autoLevels[1]).add(extraT1()).mul(t1Auto()).div(data.dy.level).div(data.chal.decrementy)
+        autoSpeed = Decimal.max(1, Decimal.min(succSpeed, maxSpeed.mul(data.ord.base)))
+    }
     return formatTime(Decimal.max((getTargetOrdinal().sub(data.ord.ordinal)).div(autoSpeed), D(0)))
 }
 function updateProgressBar(){

--- a/src/etc/settings.js
+++ b/src/etc/settings.js
@@ -2,7 +2,7 @@ const SETTINGS_DESCS = [
     "Booster Refund Confirmation", "Challenge Confirmation", "Challenge Completion Popup", "Factor Shift confirmation",
     "Factor Boost confirmation", "Charge Refund Confirmation", "Boost Progress Bar", "ability to Bulk Boost",
     "Baselessness Confirmation", "Collapse Confirmation", "Booster Refund in C5 and C7", "Darkness Confirmation",
-    "Charge Sacrifice Confirmation", "Hardy Value Display for Ordinals >= Ψ(Ω)",
+    "Charge Sacrifice Confirmation", "Hardy Value Display for Ordinals >= 1.8e308",
     "<img src='https://cdn.discordapp.com/emojis/853002327362895882.webp?size=24'> Display"
 ]
 const settingsDefaults = [true, true, true, true, true, true, true, true, true, true, true, true, false, false]

--- a/src/etc/tick.js
+++ b/src/etc/tick.js
@@ -45,7 +45,7 @@ function tick(diff){
         if (Decimal.floor(D(timesToLoop[0]).div(1000)).gte(1)) { // if there are more successors
             if (Decimal.floor(D(timesToLoop[1]).div(1000)).gte(1)) { // if there are also matching # of maximizes, do both
                 data.ord.over = 0
-                successor(Decimal.max(Decimal.min(Decimal.floor(D(timesToLoop[0]).div(1000)), D(data.ord.base).mul(Decimal.floor(D(timesToLoop[1]).div(1000))))),0)
+                successor(Decimal.max(Decimal.min(Decimal.floor(D(timesToLoop[0]).div(1000)), D(data.ord.base).mul(Decimal.floor(D(timesToLoop[1]).div(1000))))),0,true)
             } else {
                 if (Decimal.floor(D(timesToLoop[0]).div(1000)).gte(D(data.ord.base).sub(D(data.ord.ordinal).mod(data.ord.base)))) { // stop at ordinal % (base - 1) and spill the rest to over
                     let ord1 = D(data.ord.base).sub(data.ord.ordinal.mod(data.ord.base)).sub(1) //(data.ord.base - (data.ord.ordinal % data.ord.base)) - 1

--- a/src/internal/ExpantaNum.js
+++ b/src/internal/ExpantaNum.js
@@ -1,5 +1,3 @@
-// This code is hell. Ignore the errors, DO NOT TOUCH!!!!!!!!!!
-
 //Code snippets and templates from Decimal.js
 
 ;(function (globalScope) {
@@ -15,17 +13,17 @@
       // 1000 means there are at maximum of 1000 elements in array.
       // It is not recommended to make this number too big.
       // `ExpantaNum.maxOps = 1000;`
-      maxOps: 1e3,
+      maxOps: 100,
 
       // Specify what format is used when serializing for JSON.stringify
-      // 
+      //
       // JSON   0 JSON object
       // STRING 1 String
       serializeMode: 0,
-      
+
       // Deprecated
       // Level of debug information printed in console
-      // 
+      //
       // NONE   0 Show no information.
       // NORMAL 1 Show operations.
       // ALL    2 Show everything.
@@ -226,6 +224,96 @@
   Q.lessThanOrEqualTo=Q.lte=function (x,y){
     return new ExpantaNum(x).lte(y);
   };
+  P.omegalog=function(bbase) {
+    let dis = this.clone()
+    let base = ExpantaNum(bbase).clone()
+    if (dis.layer >= 1) {
+      dis.layer -= 1
+      return dis
+    } else if (dis.array[dis.array.length-1][0] >= 98) {
+      let zero=ExpantaNum(dis.array[dis.array.length-1][0])
+      return zero
+    } else if (base.pow(2).gte(dis)) {
+      return ExpantaNum(0)
+    } else {
+      let addTest = 8
+      let target = 0
+      while (addTest >= 10**-10) {
+        if (ExpantaNum.arrFrac(base,target+addTest).lte(dis)) {
+          target += addTest
+        }
+        addTest /= 2
+      }
+      return ExpantaNum(target)
+    }
+  }
+  P.hyperlog=function (order) {
+    let thingy = this.clone()
+    if (order >= 2.5) {
+      if (thingy.array[0][0]==0) thingy.array[0][1] += 1
+      thingy = thingy.normalize()
+    }
+    let l = thingy.array.length-1
+    if (order==1) {
+      return thingy.log10()
+    } else if (order==2) {
+      return thingy.slog()
+    } else if (thingy.array[l][0] >= order+1.5) {
+      return thingy
+    } else if (thingy.array[l][0] == order+1 && thingy.array[l][1]>1.5) {
+      return thingy
+    } else if (thingy.array[l][0] == order+1 && thingy.array[l][1]==1) {
+      return ExpantaNum.arrow(ExpantaNum(10),ExpantaNum(order+1),thingy.hyperlog(order+1).minus(1))
+    } else if (thingy.array[l][0] == order && thingy.array[l][1]>1.5) {
+      thingy.array[l][1] -= 1
+      return thingy
+    } else if (thingy.array[l][0] == order && thingy.array[l][1]==1) {
+      thingy.array.pop()
+      return thingy
+    } else if (thingy.array[l][0] == order-1) {
+      return ExpantaNum(thingy.array[l][1]+1)
+    } else {
+      return ExpantaNum((thingy.gte("10")?1:0))
+    }
+  }
+  Q.hyperlog=function (x,y) {
+    return new ExpantaNum(x).hyperlog(y)
+  }
+  P.simplify=function() {
+    let thingy = this.clone()
+    while (thingy.array.length >= 3) {
+      thingy.array.splice(1,1)
+    }
+    return thingy
+  }
+  P.normalize = function () {
+    let thing = this.clone()
+    thing.array[0][1] = Math.round(thing.array[0][1])
+    if (thing.array[0][1] >= 10**10-1) {
+      thing.array[0][1] = 10
+      if (thing.array.length == 1) {
+        thing.array.push([1,0])
+      }
+      thing.array[1][1] += 1
+    }
+      let lastarrow = 0
+      let counter=1
+      while (counter < thing.array.length) {
+        if (thing.array[counter][1] >= 9) {
+          lastarrow = thing.array[counter][0]
+          thing.array[0][1] = thing.array[counter][1]+1
+          for (let i=0;i<counter;i++) thing.array.splice(1,1)
+          if (thing.array.length == 1) {
+            thing.array.push([lastarrow+1,0])
+          }
+          if (thing.array[1][0] == lastarrow +1) thing.array[1][1] += 1
+          counter -= 1
+          }
+        counter++
+      }
+      if ((!typeof thing.array[1] == "undefined") && thing.array[1][1]==0) thing.array.splice(1,1)
+      return thing
+  }
   P.equalsTo=P.equal=P.eq=function (other){
     return this.cmp(other)===0;
   };
@@ -250,6 +338,11 @@
   Q.maximum=Q.max=function (x,y){
     return new ExpantaNum(x).max(y);
   };
+  Q.arrFrac=function (bb,hh) {
+    let b = ExpantaNum(bb).clone()
+    let h = ExpantaNum(hh).clone()
+    return ExpantaNum.arrow(b,h.floor().add(1),b.divide(2).pow(h.minus(h.floor())).times(2))
+  }
   P.isPositive=P.ispos=function (){
     return this.gt(ExpantaNum.ZERO);
   };
@@ -1721,21 +1814,21 @@
 
     ExpantaNum.JSON = 0;
     ExpantaNum.STRING = 1;
-    
+
     ExpantaNum.NONE = 0;
     ExpantaNum.NORMAL = 1;
     ExpantaNum.ALL = 2;
 
     ExpantaNum.clone=clone;
     ExpantaNum.config=ExpantaNum.set=config;
-    
+
     //ExpantaNum=Object.assign(ExpantaNum,Q);
     for (var prop in Q){
       if (Q.hasOwnProperty(prop)){
         ExpantaNum[prop]=Q[prop];
       }
     }
-    
+
     if (obj === void 0) obj = {};
     if (obj) {
       ps = ['maxOps', 'serializeMode', 'debug'];
@@ -1743,7 +1836,7 @@
     }
 
     ExpantaNum.config(obj);
-    
+
     return ExpantaNum;
   }
 

--- a/src/markup/markup.js
+++ b/src/markup/markup.js
@@ -11,7 +11,13 @@ function updateMarkupHTML(){
         `Perform a Factor Shift (H)<br>Requires: ${format(getFSReq())} Ordinal Powers`
     DOM("auto0").innerText = `Successor AutoClicker\nCosts ${format(autoCost(0))} Ordinal Powers`
     DOM("auto1").innerText = `Maximize AutoClicker\nCosts ${format(autoCost(1))} Ordinal Powers`
-    DOM("autoText").innerText = `Your ${formatWhole(data.autoLevels[0]+extraT1())} Successor Autoclickers click the Successor button ${formatWhole(data.chal.active[4]?(data.autoLevels[0]+extraT1())*factorBoost()/data.dy.level:(data.autoLevels[0]+extraT1())*factorBoost()*data.dy.level)} times/second\nYour ${formatWhole(data.autoLevels[1]+extraT1())} Maximize Autoclickers click the Maximize button ${formatWhole(data.chal.active[4]?(data.autoLevels[1]+extraT1())*factorBoost()/data.dy.level:(data.autoLevels[1]+extraT1())*factorBoost()*data.dy.level)} times/second`
+    let succSpeed = !data.chal.active[4]
+        ? D(data.autoLevels[0]).add(extraT1()).mul(t1Auto()).mul(data.dy.level).div(data.chal.decrementy)
+        : D(data.autoLevels[0]).add(extraT1()).mul(t1Auto()).div(data.dy.level).div(data.chal.decrementy)
+    let maxSpeed = !data.chal.active[4]
+        ? D(data.autoLevels[1]).add(extraT1()).mul(t1Auto()).mul(data.dy.level).div(data.chal.decrementy)
+        : D(data.autoLevels[1]).add(extraT1()).mul(t1Auto()).div(data.dy.level).div(data.chal.decrementy)
+    DOM("autoText").innerText = `Your ${formatWhole(data.autoLevels[0]+extraT1())} Successor Autoclickers click the Successor button ${formatWhole(succSpeed)} times/second\nYour ${formatWhole(data.autoLevels[1]+extraT1())} Maximize Autoclickers click the Maximize button ${formatWhole(maxSpeed)} times/second`
 
     for (let i = 0; i < data.factors.length; i++) {
         DOM(`factor${i}`).innerText = hasFactor(i)?`Factor ${i+1} [${data.boost.hasBUP[11]?formatWhole(data.factors[i]+3):formatWhole(data.factors[i])}] ${formatWhole(factorEffect(i))}x\nCost: ${formatWhole(factorCost(i))} Ordinal Powers`:`Factor ${i+1}\nLOCKED`

--- a/src/markup/markup.js
+++ b/src/markup/markup.js
@@ -4,7 +4,7 @@ function updateMarkupHTML(){
 
     DOM("markupButton").innerHTML =
         data.ord.isPsi&&data.ord.ordinal.eq(GRAHAMS_VALUE)&&data.boost.times===0&&!data.collapse.hasSluggish[0]?`Base 2 is required to go further...`:
-        data.ord.isPsi?`Markup and gain ${displayPsiOrd(data.ord.ordinal.plus(1), 4)} (I)`:
+        data.ord.isPsi?`Markup and gain ${ordinalDisplay('', data.ord.ordinal.plus(1), data.ord.over, data.ord.base, ((data.ord.displayType === "BMS") || (data.ord.displayType === "Y-Sequence")) ? Math.max(data.ord.trim, 4) : 4)} (I)`:
         data.ord.ordinal.gte(data.ord.base**2)?`Markup and gain ${formatWhole(opGain()*opMult())} Ordinal Powers (I)`:`H<sub>ω<sup>2</sup></sub>(${data.ord.base}) is required to Markup...`
 
     DOM("factorShiftButton").innerHTML = data.ord.base===3?data.boost.times>0||data.collapse.hasSluggish[0]?`Perform a Factor Shift<br>Requires: ?????`:`Perform a Factor Shift<br>Requires: Graham's Number (H<sub>ψ(Ω<sup>Ω</sup>ω)</sub>(3))`:

--- a/src/markup/markup.js
+++ b/src/markup/markup.js
@@ -25,7 +25,7 @@ function updateMarkupHTML(){
     DOM("dynamicText").innerText = `Your Dynamic Factor is ${data.chal.active[4]?'dividing':'multiplying'} AutoClickers by ${format(data.dy.level, 3)}\nIt increases by ${format(dyGain())}/s, and caps at ${format(data.dy.cap)}`
     DOM("dynamicText2").innerText = `Your Dynamic Factor is ${format(data.dy.level, 3)} [+${format(dyGain())}/s]. It caps at ${format(data.dy.cap)}`
 
-    DOM("factorBoostButton").innerHTML = `Perform ${getBulkBoostAmt() < 2 ? `${inAnyPurification() ? `an` : `a`} ${boostName()} Boost` : getBulkBoostAmt()+` ${boostName()} Boosts`} [+${boosterGain()}] (B)<br>Requires ${displayPsiOrd(boostReq(), 3)}`
+    DOM("factorBoostButton").innerHTML = `Perform ${getBulkBoostAmt() < 2 ? `${inAnyPurification() ? `an` : `a`} ${boostName()} Boost` : getBulkBoostAmt()+` ${boostName()} Boosts`} [+${boosterGain()}] (B)<br>Requires ${displayBoostReq()}`
     DOM("factorBoostButton").style.color = data.ord.isPsi&&data.ord.ordinal.gte(boostReq())?'#fff480':'#8080FF'
 
     if(data.sToggles[6]) updateProgressBar()

--- a/src/ordinal/displayBMSOrd.js
+++ b/src/ordinal/displayBMSOrd.js
@@ -8,8 +8,8 @@ function trimBMSFinalOutput(output, trim = data.ord.trim) {
 }
 
 // Displays Ordinals using BMS when the value of ord is less than NUMBER.MAX_VALUE
-function displayBMSOrd(ord, over, base, trim = data.ord.trim, depth = 0, final = true) {
-    if(data.ord.isPsi) return displayPsiBMSOrd(ord, trim)
+function displayBMSOrd(ord, over, base, trim = data.ord.trim, depth = 0, final = true, forcePsi = false) {
+    if(data.ord.isPsi || forcePsi) return displayPsiBMSOrd(ord, trim)
     if(ord === data.ord.ordinal && ord.gt(Number.MAX_VALUE)) return displayInfiniteBMSOrd(ord, over, base, trim)
     if(ord === data.ord.ordinal) ord = Number(ord)
 

--- a/src/ordinal/displayBMSOrd.js
+++ b/src/ordinal/displayBMSOrd.js
@@ -126,7 +126,7 @@ function displayPsiBMSOrd(ord, trim = data.ord.trim, base = data.ord.base, depth
             break;
     }
     if(buchholzOutput.includes("x"))finalOutput = finalOutput + displayPsiBMSOrd(ord-magnitudeAmount, trim-1, base, depth+add, false)
-    if(buchholzOutput.includes("y"))finalOutput = removeLastBMSEntry(finalOutput) + displayPsiBMSOrd(ord-magnitudeAmount+1, trim-1, base, depth+add+1, false)
+    if(buchholzOutput.includes("y"))finalOutput = removeLastBMSEntry(finalOutput) + displayPsiBMSOrd(Math.max(ord-magnitudeAmount+1, 1), trim-1, base, depth+add+1, false)
     if (final) finalOutput = trimBMSFinalOutput(finalOutput, trim)
     return `${finalOutput.replaceAll('undefined', '')}`
 }
@@ -168,7 +168,7 @@ function displayInfinitePsiBMSOrd(ord, trim = data.ord.trim, base = data.ord.bas
             break;
     }
     if(buchholzOutput.includes("x"))finalOutput = finalOutput + displayInfinitePsiBMSOrd(ord.sub(magnitudeAmount), trim-1, base, depth+add)
-    if(buchholzOutput.includes("y"))finalOutput = removeLastBMSEntry(finalOutput) + displayInfinitePsiBMSOrd(ord.sub(magnitudeAmount).plus(1), trim-1, base, depth+add+1)
+    if(buchholzOutput.includes("y"))finalOutput = removeLastBMSEntry(finalOutput) + displayInfinitePsiBMSOrd(Decimal.max(ord.sub(magnitudeAmount).plus(1), D(1)), trim-1, base, depth+add+1)
     if (final) finalOutput = trimBMSFinalOutput(finalOutput, trim)
     return `${finalOutput.replaceAll('undefined', '')}`
 }

--- a/src/ordinal/displayOrd.js
+++ b/src/ordinal/displayOrd.js
@@ -1,6 +1,6 @@
 // Displays Ordinals when the value of ord is less than NUMBER.MAX_VALUE
-function displayOrd(ord,over,base,trim = data.ord.trim) {
-    if(data.ord.isPsi) return displayPsiOrd(ord, trim)
+function displayOrd(ord,over,base,trim = data.ord.trim,forcePsi = false) {
+    if(data.ord.isPsi || forcePsi) return displayPsiOrd(ord, trim)
     if(ord === data.ord.ordinal && ord.gt(Number.MAX_VALUE)) return displayInfiniteOrd(ord, over, base, trim)
     if(ord === data.ord.ordinal) ord = Number(ord)
 

--- a/src/ordinal/displayPsiOrd.js
+++ b/src/ordinal/displayPsiOrd.js
@@ -41,6 +41,6 @@ function displayInfinitePsiOrd(ord, trim = data.ord.trim, base = data.ord.base) 
     const magnitudeAmount = D(4).times(Decimal.pow(3, magnitude))
     let finalOutput = infiniteOrdMarks(Decimal.min(magnitude,ordMarksXStart[ordMarksXStart.length-1])) //ordMarks[Decimal.min(magnitude,ordMarks.length-1)]
     if(finalOutput.includes("x"))finalOutput = finalOutput.replace(/x/, displayInfinitePsiOrd(ord.sub(magnitudeAmount), trim-1))
-    if(finalOutput.includes("y"))finalOutput = finalOutput.replace(/y/, displayInfinitePsiOrd(Decimal.max(ord.sub(magnitudeAmount).plus(1), 1), trim-1))
+    if(finalOutput.includes("y"))finalOutput = finalOutput.replace(/y/, displayInfinitePsiOrd(Decimal.max(ord.sub(magnitudeAmount).plus(1), D(1)), trim-1))
     return `${finalOutput.replaceAll('undefined', '')}`
 }

--- a/src/ordinal/displayPsiOrd.js
+++ b/src/ordinal/displayPsiOrd.js
@@ -18,7 +18,7 @@ function displayPsiOrd(ord, trim = data.ord.trim, base = data.ord.base) {
     const magnitudeAmount = 4*3**magnitude
     let finalOutput = ordMarks[Math.min(magnitude,ordMarks.length-1)]
     if(finalOutput.includes("x"))finalOutput = finalOutput.replace(/x/, displayPsiOrd(ord-magnitudeAmount, trim-1))
-    if(finalOutput.includes("y"))finalOutput = finalOutput.replace(/y/, displayPsiOrd(ord-magnitudeAmount+1, trim-1))
+    if(finalOutput.includes("y"))finalOutput = finalOutput.replace(/y/, displayPsiOrd(Math.max(ord-magnitudeAmount+1, 1), trim-1))
     return `${finalOutput.replaceAll('undefined', '')}`
 }
 
@@ -41,6 +41,6 @@ function displayInfinitePsiOrd(ord, trim = data.ord.trim, base = data.ord.base) 
     const magnitudeAmount = D(4).times(Decimal.pow(3, magnitude))
     let finalOutput = infiniteOrdMarks(Decimal.min(magnitude,ordMarksXStart[ordMarksXStart.length-1])) //ordMarks[Decimal.min(magnitude,ordMarks.length-1)]
     if(finalOutput.includes("x"))finalOutput = finalOutput.replace(/x/, displayInfinitePsiOrd(ord.sub(magnitudeAmount), trim-1))
-    if(finalOutput.includes("y"))finalOutput = finalOutput.replace(/y/, displayInfinitePsiOrd(ord.sub(magnitudeAmount).plus(1), trim-1))
+    if(finalOutput.includes("y"))finalOutput = finalOutput.replace(/y/, displayInfinitePsiOrd(Decimal.max(ord.sub(magnitudeAmount).plus(1), 1), trim-1))
     return `${finalOutput.replaceAll('undefined', '')}`
 }

--- a/src/ordinal/displayVeblenOrd.js
+++ b/src/ordinal/displayVeblenOrd.js
@@ -55,7 +55,7 @@ function displayPsiVeblenOrd(ord, trim = data.ord.trim, base = data.ord.base) {
     const magnitudeAmount = 4*3**magnitude
     let finalOutput = ordMarksVeblen[Math.min(magnitude,ordMarksVeblen.length-1)]
     if(finalOutput.includes("x"))finalOutput = finalOutput.replace(/x/, displayPsiVeblenOrd(ord-magnitudeAmount, trim-1))
-    if(finalOutput.includes("y"))finalOutput = finalOutput.replace(/y/, displayPsiVeblenOrd(ord-magnitudeAmount+1, trim-1))
+    if(finalOutput.includes("y"))finalOutput = finalOutput.replace(/y/, displayPsiVeblenOrd(Math.max(ord-magnitudeAmount+1, 1), trim-1))
     return `${finalOutput.replaceAll('undefined', '')}`
 }
 
@@ -80,6 +80,6 @@ function displayInfinitePsiVeblenOrd(ord, trim = data.ord.trim, base = data.ord.
     const magnitudeAmount = D(4).times(Decimal.pow(3, magnitude))
     let finalOutput = infiniteOrdMarksVeblen(Decimal.min(magnitude,ordMarksXStart[ordMarksXStart.length-1])) //ordMarks[Decimal.min(magnitude,ordMarks.length-1)]
     if(finalOutput.includes("x"))finalOutput = finalOutput.replace(/x/, displayInfinitePsiVeblenOrd(ord.sub(magnitudeAmount), trim-1))
-    if(finalOutput.includes("y"))finalOutput = finalOutput.replace(/y/, displayInfinitePsiVeblenOrd(ord.sub(magnitudeAmount).plus(1), trim-1))
+    if(finalOutput.includes("y"))finalOutput = finalOutput.replace(/y/, displayInfinitePsiVeblenOrd(Decimal.max(ord.sub(magnitudeAmount).plus(1), D(1)), trim-1))
     return `${finalOutput.replaceAll('undefined', '')}`
 }

--- a/src/ordinal/displayVeblenOrd.js
+++ b/src/ordinal/displayVeblenOrd.js
@@ -1,6 +1,6 @@
 // Displays Ordinals using Veblen when the value of ord is less than NUMBER.MAX_VALUE
-function displayVeblenOrd(ord,over,base,trim = data.ord.trim) {
-    if(data.ord.isPsi) return displayPsiVeblenOrd(ord, trim)
+function displayVeblenOrd(ord,over,base,trim = data.ord.trim,forcePsi = false) {
+    if(data.ord.isPsi || forcePsi) return displayPsiVeblenOrd(ord, trim)
     if(ord === data.ord.ordinal && ord.gt(Number.MAX_VALUE)) return displayInfiniteVeblenOrd(ord, over, base, trim)
     if(ord === data.ord.ordinal) ord = Number(ord)
 

--- a/src/ordinal/displayYSequenceOrd.js
+++ b/src/ordinal/displayYSequenceOrd.js
@@ -45,27 +45,12 @@ function BMS2RowToYSeq(output, trim = data.ord.trim) {
 // Displays Ordinals using Y-Sequence when the value of ord is less than NUMBER.MAX_VALUE
 function displayYSeqOrd(ord, over, base, trim = data.ord.trim, depth = 0, final = true) {
     let BMSOutput = trimBMSFinalOutput(displayBMSOrd(ord, over, base, trim, depth, final), trim)
-    return (D(ord).toNumber() >= 1) ? (data.ord.isPsi ? BMS2RowToYSeq(BMSOutput, trim) : BMS1RowToYSeq(BMSOutput, trim)) : "()"
+    if (data.ord.isPsi && D(ord).toNumber() >= 0 && D(ord).toNumber() < 4) return ["(1)","(1,2)","(1,2,3)","(1,2,3,3)"][Math.floor(D(ord).toNumber())]
+    return (D(ord).toNumber() >= 1) ? (data.ord.isPsi ? BMS2RowToYSeq(BMSOutput, trim - 1) : BMS1RowToYSeq(BMSOutput, trim)) : "()"
 }
 
 // Displays Ordinals using Y-Sequence when the value of ord is greater than NUMBER.MAX_VALUE
 function displayInfiniteYSeqOrd(ord, over, base, trim = data.ord.trim, depth = 0, final = true, recursionDepth = 0){
     let BMSOutput = trimBMSFinalOutput(displayInfiniteBMSOrd(ord, over, base, trim, depth, final, recursionDepth), trim)
     return D(ord).gte(1) ? BMS1RowToYSeq(BMSOutput, trim) : "()"
-}
-
-// Displays Ordinals using Y-Sequence and Psi when the value of ord is less than NUMBER.MAX_VALUE
-function displayPsiYSeqOrd(ord, trim = data.ord.trim, base = data.ord.base, depth = 0, final = true) {
-    let BMSOutput = trimBMSFinalOutput(displayPsiBMSOrd(ord, trim, base, depth, final), trim)
-    if (D(ord).toNumber() < 0) return "()"
-    if (D(ord).toNumber() < 4) return ["(1)","(1,2)","(1,2,3)","(1,2,3,3)"][Math.floor(D(ord).toNumber())]
-    return BMS2RowToYSeq(BMSOutput, trim)
-}
-
-//Displays Ordinals using Y-Sequence and Psi when the value of ord is greater than NUMBER.MAX_VALUE
-function displayInfinitePsiYSeqOrd(ord, trim = data.ord.trim, base = data.ord.base, depth = 0, final = true) {
-    let BMSOutput = trimBMSFinalOutput(displayInfinitePsiBMSOrd(ord, trim, base, depth, final), trim)
-    if (D(ord).lt(0)) return "()"
-    if (D(ord).lt(4)) return ["(1)","(1,2)","(1,2,3)","(1,2,3,3)"][Math.floor(D(ord).toNumber())]
-    return BMS2RowToYSeq(BMSOutput, trim)
 }

--- a/src/ordinal/displayYSequenceOrd.js
+++ b/src/ordinal/displayYSequenceOrd.js
@@ -43,10 +43,10 @@ function BMS2RowToYSeq(output, trim = data.ord.trim) {
 }
 
 // Displays Ordinals using Y-Sequence when the value of ord is less than NUMBER.MAX_VALUE
-function displayYSeqOrd(ord, over, base, trim = data.ord.trim, depth = 0, final = true) {
+function displayYSeqOrd(ord, over, base, trim = data.ord.trim, depth = 0, final = true, forcePsi = false) {
     let BMSOutput = trimBMSFinalOutput(displayBMSOrd(ord, over, base, trim, depth, final), trim)
     if (data.ord.isPsi && D(ord).toNumber() >= 0 && D(ord).toNumber() < 4) return ["(1)","(1,2)","(1,2,3)","(1,2,3,3)"][Math.floor(D(ord).toNumber())]
-    return (D(ord).toNumber() >= 1) ? (data.ord.isPsi ? BMS2RowToYSeq(BMSOutput, trim - 1) : BMS1RowToYSeq(BMSOutput, trim)) : "()"
+    return (D(ord).toNumber() >= 1) ? ((data.ord.isPsi || forcePsi) ? BMS2RowToYSeq(BMSOutput, trim - 1) : BMS1RowToYSeq(BMSOutput, trim)) : "()"
 }
 
 // Displays Ordinals using Y-Sequence when the value of ord is greater than NUMBER.MAX_VALUE

--- a/src/ordinal/gwaifyOrdinal.js
+++ b/src/ordinal/gwaifyOrdinal.js
@@ -8,7 +8,7 @@ function gwaifyOrdinal(ord){
         .replaceAll("Ω<sub>2</sub>","<img src='res/gwaify/voidgwa.webp'>")
         .replaceAll("Ω","<img src='res/gwaify/tetris.webp'>")
         .replaceAll("ω", "<img src='res/gwaify/gwa.webp'>")
-        .replaceAll("&omega","<img src='res/gwaify/gwa.webp'>")
+        .replaceAll("&omega;","<img src='res/gwaify/gwa.webp'>")
         .replaceAll("&phi;","<img src='res/gwaify/gwarnament.webp'>")
         .replaceAll('9', "<img src='res/gwaify/gwaold.webp'>")
         .replaceAll('8', "<img src='res/gwaify/gwatrollfront.webp'>")

--- a/src/ordinal/hardy.js
+++ b/src/ordinal/hardy.js
@@ -140,18 +140,18 @@ function hardy(ord, base, over=0)
 function rep(mult, restOrd, base, over=0)
 {
     if (EN(mult).eq(1)) {
-        if (hardy(EN(base ** (base + 1)).add(restOrd), base, over) !== Infinity) {
+        if (EN_format(hardy(EN(base ** (base + 1)).add(restOrd), base, over)) !== "Infinity") {
             return parseInt(beautifyEN(hardy(EN(base ** (base + 1)).add(restOrd), base, over)).split("}}")[1])
         }
         return 3;
     }
-    return beautifyEN(hardy(EN(base ** base).times(2).add(restOrd), base, over)).split("{{").length + mult.toNumber() + 1;
+    return beautifyEN(hardy(EN(base ** base).times(2).add(restOrd), base, over)).split("{{").length + mult.toNumber();
 }
 
 function isHugeRep(mult, restOrd, base, over=0)
 {
     if (EN(mult).eq(1)) {
-        if (hardy(EN(base ** (base + 1)).add(restOrd), base, over) !== Infinity) {
+        if (EN_format(hardy(EN(base ** (base + 1)).add(restOrd), base, over)) !== "Infinity") {
             return false;
         }
     }
@@ -175,10 +175,9 @@ function bigHardy(ord, base, over=0)
     // w+1 level (includes handling above EN limit, simplified into 10{{2}}n)
     if (highestPower.eq(base + 1))
     {
-        if (hardy(ord1, base, over) !== Infinity) {
+        if (EN_format(hardy(ord1, base, over)) !== "Infinity") {
             return EN_format(hardy(ord1, base, over));
         }
-
         return base + "{{2}}" + rep(highestPowerMult, restOrd, base, over);
     }
 
@@ -603,8 +602,7 @@ function calculateHardy(ord = data.ord.ordinal, over = data.ord.over, base = dat
 
     let highestPower = ord.log10().div(Decimal.log10(base)).floor();
     let restOrd = ord.sub(Decimal.pow(base, highestPower));
-
-    return fgh(highestPower, calculateHardy(restOrd, over, base));
+    return fgh(highestPower.toNumber(), calculateHardy(restOrd, over, base));
 }
 
 // Calculates the Hardy Value up to 1.79e308
@@ -626,17 +624,14 @@ function calculateSimpleHardy(ord = data.ord.ordinal, over = data.ord.over, base
 
 // Get the Hardy Value for Display
 function getHardy(ord = data.ord.ordinal, over = data.ord.over, base = data.ord.base, isPsi = data.ord.isPsi) {
+    if (isPsi) return psiHardy(ord, base);
     if(calculateSimpleHardy().lt(Number.MAX_VALUE)) return format(Decimal.floor(calculateSimpleHardy()))
     ord = Decimal.floor(ord);
     let hardyValue = "Infinity";
-    if (isPsi) return psiHardy(ord, base);
-    return
-    /*
     hardyValue = format(calculateHardy(ord, over, base));
     if (hardyValue === "Infinity") {
         hardyValue = EN_format(hardy(ord, base, over));
         if (hardyValue === "Infinity") hardyValue = bigHardy(ord, base, over);
     }
     return hardyValue;
-     */
 }

--- a/src/ordinal/hardy.js
+++ b/src/ordinal/hardy.js
@@ -341,7 +341,25 @@ function psiHardy(ord, base) {
     if (ord.toString() === "NaNeInfinity") return "Ω"; // Absolute Infinity
 
     // psi base 3+ - ultra-simplified (1 value per ordinal level), in reverse order (value represents the highest ordinal level at or below current ordinal)
-    if (ord.gte(BHO_VALUE * (3**616))) return "{3,3[1[1[1/2/<sub>3</sub>2]3]2]2}"; // θ(θ1(Ω,1)) = θ(φ(Ω,2)) = Ω₂^Ωψ1(Ω₂²) (current ordMarks limit, not reachable as it's above Number.MAX_VALUE)
+    if (ord.gte(D(BHO_VALUE).mul("eee98235035280650.45"))) return "{3,3[1[2/<sub>1,2</sub>2]2]2}"; // θ(Ω_ω) = Ω_ω (LIMIT for base 3)
+    if (ord.gte(D(BHO_VALUE).mul("eee38.32545039616217"))) return "{3,3[1[1[1~1/2/<sub>3</sub>2]2]2]2}"; // θ(Ω₂^Ω) = Ω₂^(Ω₂^Ω)
+    if (ord.gte(D(BHO_VALUE).mul("eee25.44317651873129"))) return "{3,3[1[1[1~3/<sub>3</sub>2]2]2]2}"; // θ(Ω₂²) = Ω₂^(Ω₂²)
+    if (ord.gte(D(BHO_VALUE).mul("ee98235035280664.72"))) return "{3,3[1[1[1/1/2~2/<sub>3</sub>2]1~2]2]2}"; // θ(Ω₂(Ω^Ω)) = Ω₂^(Ω₂(Ω^Ω))
+    if (ord.gte(D(BHO_VALUE).mul("ee10915003920074.89"))) return "{3,3[1[1[1/2~2/<sub>3</sub>2]1~2]2]2}"; // θ(Ω₂Ω) = Ω₂^(Ω₂Ω)
+    if (ord.gte(D(BHO_VALUE).mul("ee7276669280050.317"))) return "{3,3[1[1[1~2/<sub>3</sub>2]1~2]2]2}"; // θ(Ω₂2) = Ω₂^(Ω₂2)
+    if (ord.gte(D(BHO_VALUE).mul("ee3638334640026.1675"))) return "{3,3[1[1[1~2/<sub>3</sub>2]1~2]2]2}"; // θ(Ω₂+1) = Ω₂^(Ω₂+1)
+    if (ord.gte(D(BHO_VALUE).mul("ee3638334640025.5654"))) return "{3,3[1[1[1~2/<sub>3</sub>2]2]2]2}"; // θ(Ω₂) = Ω₂^Ω₂
+    if (ord.gte(D(BHO_VALUE).mul("ee3638334640025.3896"))) return "{3,3[1[1[1[1[1[1~3]2/<sub>3</sub>2]2]2/<sub>3</sub>2]2]2]2}"; // θ(θ₁(θ₁(θ₁(1)))) = Ω₂^ψ₁(Ω₂^ψ₁(Ω₂))
+    if (ord.gte(D(BHO_VALUE).mul("ee3638334640025.0884"))) return "{3,3[1[1[1[1~3]2/<sub>3</sub>2]2]2]2}"; // θ(θ₁(θ₁(1))) = Ω₂^ψ₁(Ω₂)
+    if (ord.gte(D(BHO_VALUE).mul("ee9392.169261382569"))) return "{3,3[1[1[1/1/1/2/<sub>3</sub>2]2]2]2}"; // θ(θ₁(Ω^Ω²)) = Ω₂^(Ω^Ω²)
+    if (ord.gte(D(BHO_VALUE).mul(Decimal.pow(3, 156765267918869)))) return "{3,3[1[1[1/1/2/<sub>3</sub>2]2]2]2}"; // θ(θ₁(Ω^Ω)) = Ω₂^(Ω^Ω) (current "Pringles limit")
+    if (ord.gte(D(BHO_VALUE).mul(Decimal.pow(3, 404575)))) return "{3,3[1[1[1/3/<sub>3</sub>2]2]2]2}"; // θ(θ₁(Ω²)) = Ω₂^(Ω²)
+    if (ord.gte(D(BHO_VALUE).mul(Decimal.pow(3, 404574)).mul(2))) return "{3,3[1[1[1[1[1[1/2/<sub>3</sub>2]2]2]2/2/<sub>3</sub>2]2]2]2}"; // θ(θ₁(Ωθ(θ₁(Ω)))) = Ω₂^(Ωψ₁(Ω₂^Ωω))
+    if (ord.gte(D(BHO_VALUE).mul(Decimal.pow(3, 404574)))) return "{3,3[1[1[2/2/<sub>3</sub>2]2]2]2}"; // θ(θ₁(Ωω)) = Ω₂^(Ωω)
+    if (ord.gte(D(BHO_VALUE).mul(Decimal.pow(3, 14924)))) return "{3,3[1[1[1/2/<sub>3</sub>2]1[1/2/<sub>3</sub>2]2]2]2}"; // θ(θ₁(Ω2)) = Ω₂^(Ω2)
+    if (ord.gte(D(BHO_VALUE).mul(Decimal.pow(3, 1603)))) return "{3,3[1[1[1/2/<sub>3</sub>2]1~2]2]2}"; // θ(θ₁(Ω+1)) = Ω₂^(Ω+1)
+    if (ord.gte(D(BHO_VALUE).mul(Decimal.pow(3, 863)))) return "{3,3[1[1[1/2/<sub>3</sub>2]1[1[1/2/<sub>3</sub>2]2]2]2]2}"; // θ(θ₁(Ω, θ₁(Ω))) = Ω₂^Ωψ₁(Ω₂^Ω)
+    if (ord.gte(D(BHO_VALUE).mul(Decimal.pow(3, 616)))) return "{3,3[1[1[1/2/<sub>3</sub>2]3]2]2}"; // θ(θ₁(Ω,1)) = θ(φ(Ω,2)) = Ω₂^Ωψ₁(Ω₂²) (current non-infinite ordMarks limit)
     if (ord.gte(BHO_VALUE * (3**493))) return "{3,3[1[1[1/2/<sub>3</sub>2]2]2]2}"; // θ(θ1(Ω)) = θ(φ(Ω,1)) = Ω₂^Ω (highest level reachable below Number.MAX_VALUE)
     if (ord.gte(BHO_VALUE * (3**492))) return "{3,3[1[1[2/<sub>3</sub>2]2]2]2}"; // φ(ω,Ω+1) = Ω₂^ω
     if (ord.gte(BHO_VALUE * (3**369))) return "{3,3[1[1~1~1[1~1~1[1~1~2]2]2]2]2}"; // ζ(ζ(ζ(Ω+1))) = Ω₂²ψ1(Ω₂²ψ1(Ω₂²))

--- a/src/ordinal/ordinal.js
+++ b/src/ordinal/ordinal.js
@@ -1,9 +1,9 @@
 // Increases the Ordinal Successor
-function successor(n = 1, m=false) {
+function successor(n = 1, m=false, alsoMaximize=false) {
     if(data.chal.active[6] && data.successorClicks >= 1000 && m) return
     if(data.ord.isPsi) return
     if(m)++data.successorClicks
-    if (data.ord.ordinal.mod(data.ord.base) >= data.ord.base - 1 && data.ord.ordinal.lt(Number.MAX_SAFE_INTEGER) && isFinite(D(data.ord.over).plus(n))) data.ord.over+=D(n).toNumber()
+    if (data.ord.ordinal.mod(data.ord.base) >= data.ord.base - 1 && data.ord.ordinal.lt(Number.MAX_SAFE_INTEGER) && isFinite(D(data.ord.over).plus(n)) && !alsoMaximize) data.ord.over+=D(n).toNumber()
     else data.ord.ordinal = data.ord.ordinal.plus(n)
 }
 

--- a/src/ordinal/ordinalDisplay.js
+++ b/src/ordinal/ordinalDisplay.js
@@ -59,43 +59,45 @@ function updateOrdHTML(){
 function displayOrdMarks(x){
     let ordMark = "Oops! You shouldn't see this!"
 
+    x = D(Decimal.floor(D(x).add(0.000000000001)))
+
     if(data.ord.displayType === "Buchholz"){
-        ordMark = x < ordMarks.length
-            ? ordMarks[x].replace(/x/, '').replace(/y/, 'ω')
-            : (x <= ordMarksXStart[ordMarksXStart.length-1]
+        ordMark = x.lt(ordMarks.length)
+            ? ordMarks[x.toNumber()].replace(/x/, '').replace(/y/, 'ω')
+            : (x.lte(ordMarksXStart[ordMarksXStart.length-1])
                 ? infiniteOrdMarks(x).replace(/x/, '').replace(/y/, 'ω')
-                : infiniteOrdMarks(ordMarksXStart[ordMarksXStart.length-1])+'x'+format(Decimal.pow(3,x-ordMarksXStart[ordMarksXStart.length-1]))
+                : infiniteOrdMarks(ordMarksXStart[ordMarksXStart.length-1])+'x'+format(Decimal.pow(3,x.sub(ordMarksXStart[ordMarksXStart.length-1])))
               )
     }
 
     if(data.ord.displayType === "Veblen"){
-        ordMark = x < ordMarks.length
-            ? ordMarksVeblen[x].replace(/x/, '0').replace(/y/, 'φ(1)')
-            : (x <= ordMarksXStart[ordMarksXStart.length-1]
+        ordMark = x.lt(ordMarks.length)
+            ? ordMarksVeblen[x.toNumber()].replace(/x/, '0').replace(/y/, 'φ(1)')
+            : (x.lte(ordMarksXStart[ordMarksXStart.length-1])
                 ? infiniteOrdMarksVeblen(x).replace(/x/, '0').replace(/y/, 'φ(1)')
-                : infiniteOrdMarksVeblen(ordMarksXStart[ordMarksXStart.length-1])+'x'+format(Decimal.pow(3,x-ordMarksXStart[ordMarksXStart.length-1]))
+                : infiniteOrdMarksVeblen(ordMarksXStart[ordMarksXStart.length-1])+'x'+format(Decimal.pow(3,x.sub(ordMarksXStart[ordMarksXStart.length-1])))
               )
     }
 
     if(data.ord.displayType === "BMS"){
-        ordMark = x < ordMarks.length
-            ? ordMarksBMS[x]
-            : (x <= ordMarksXStart[ordMarksXStart.length-1]
+        ordMark = x.lt(ordMarks.length)
+            ? ordMarksBMS[x.toNumber()]
+            : (x.lte(ordMarksXStart[ordMarksXStart.length-1])
                 ? infiniteOrdMarksBMS(x)
-                : infiniteOrdMarksBMS(ordMarksXStart[ordMarksXStart.length-1])+'x'+format(Decimal.pow(3,x-ordMarksXStart[ordMarksXStart.length-1]))
+                : infiniteOrdMarksBMS(ordMarksXStart[ordMarksXStart.length-1])+'x'+format(Decimal.pow(3,x.sub(ordMarksXStart[ordMarksXStart.length-1])))
               )
     }
 
     if(data.ord.displayType === "Y-Sequence"){
-        ordMark = x < ordMarks.length
-            ? ordMarksBMS[x]
-            : (x <= ordMarksXStart[ordMarksXStart.length-1]
+        ordMark = x.lt(ordMarks.length)
+            ? ordMarksBMS[x.toNumber()]
+            : (x.lte(ordMarksXStart[ordMarksXStart.length-1])
                 ? infiniteOrdMarksBMS(x)
                 : infiniteOrdMarksBMS(ordMarksXStart[ordMarksXStart.length-1])
               )
         let n = ordMark.split(')(').length
         ordMark = BMS2RowToYSeq(ordMark, n)
-        if (x > ordMarksXStart[ordMarksXStart.length-1]) ordMark = ordMark+'x'+format(Decimal.pow(3,x-ordMarksXStart[ordMarksXStart.length-1]))
+        if (x.gt(ordMarksXStart[ordMarksXStart.length-1])) ordMark = ordMark+'x'+format(Decimal.pow(3,x.sub(ordMarksXStart[ordMarksXStart.length-1])))
     }
 
     return gwaifyOrdinal(ordMark)

--- a/src/ordinal/ordinalDisplay.js
+++ b/src/ordinal/ordinalDisplay.js
@@ -38,7 +38,7 @@ function changeTrim(x){
 
 // Updates the Ordinal's HTML
 function updateOrdHTML(){
-    if((!data.sToggles[13] || (data.sToggles[13] && !data.ord.isPsi)) && calculateSimpleHardy().gte(Number.MAX_VALUE)){
+    if(!data.sToggles[13] && data.ord.isPsi){
         if(data.ord.color){
             let date = Date.now()/100
             return DOM("ordinal").innerHTML = `${colorWrap(ordinalDisplay("H"), HSL(date))} ${colorWrap(`(${data.ord.base})`, HSL(date))}`

--- a/src/ordinal/ordinalDisplay.js
+++ b/src/ordinal/ordinalDisplay.js
@@ -38,7 +38,7 @@ function changeTrim(x){
 
 // Updates the Ordinal's HTML
 function updateOrdHTML(){
-    if(!data.sToggles[13] && data.ord.isPsi){
+    if(!data.sToggles[13] && (data.ord.isPsi || calculateSimpleHardy().gte(Number.MAX_VALUE))) {
         if(data.ord.color){
             let date = Date.now()/100
             return DOM("ordinal").innerHTML = `${colorWrap(ordinalDisplay("H"), HSL(date))} ${colorWrap(`(${data.ord.base})`, HSL(date))}`

--- a/src/ordinal/ordinalDisplay.js
+++ b/src/ordinal/ordinalDisplay.js
@@ -1,29 +1,33 @@
 // The entry point for Ordinal Display
-function ordinalDisplay(type, ord=data.ord.ordinal, over=data.ord.over, base=data.ord.base, trim=data.ord.trim, d=true) {
+function ordinalDisplay(type='', ord=data.ord.ordinal, over=data.ord.over, base=data.ord.base, trim=data.ord.trim, d=true) {
     let ordinal = "Oops! You shouldn't see this!"
 
     if(data.ord.displayType === "Buchholz"){
         ordinal = d
-            ? `${type}<sub>${displayOrd(ord, Math.floor(over), base, trim)}</sub>`
-            : `${type}<sub>${displayInfiniteOrd(ord, Math.floor(over), base, trim)}</sub>`
+            ? displayOrd(ord, Math.floor(over), base, trim)
+            : displayInfiniteOrd(ord, Math.floor(over), base, trim)
     }
 
     if(data.ord.displayType === "Veblen"){
         ordinal = d
-            ? `${type}<sub>${displayVeblenOrd(ord, Math.floor(over), base, trim)}</sub>`
-            : `${type}<sub>${displayInfiniteVeblenOrd(ord, Math.floor(over), base, trim)}</sub>`
+            ? displayVeblenOrd(ord, Math.floor(over), base, trim)
+            : displayInfiniteVeblenOrd(ord, Math.floor(over), base, trim)
     }
 
     if(data.ord.displayType === "BMS"){
         ordinal = d
-            ? `${type}<sub>${displayBMSOrd(ord, Math.floor(over), base, trim)}</sub>`
-            : `${type}<sub>${displayInfiniteBMSOrd(ord, Math.floor(over), base, trim)}</sub>`
+            ? displayBMSOrd(ord, Math.floor(over), base, trim)
+            : displayInfiniteBMSOrd(ord, Math.floor(over), base, trim)
     }
 
     if(data.ord.displayType === "Y-Sequence"){
         ordinal = d
-            ? `${type}<sub>${displayYSeqOrd(ord, Math.floor(over), base, trim)}</sub>`
-            : `${type}<sub>${displayInfiniteYSeqOrd(ord, Math.floor(over), base, trim)}</sub>`
+            ? displayYSeqOrd(ord, Math.floor(over), base, trim)
+            : displayInfiniteYSeqOrd(ord, Math.floor(over), base, trim)
+    }
+
+    if (type !== '') {
+        ordinal = `${type}<sub>${ordinal}</sub>`
     }
 
     return gwaifyOrdinal(ordinal)
@@ -50,4 +54,57 @@ function updateOrdHTML(){
         return DOM(`ordinal`).innerHTML = `${colorWrap(`${ordinalDisplay("H")} (${data.ord.base})=${(getHardy(data.ord.ordinal, data.ord.over, data.ord.base))}`, HSL(date))}`
     }
     DOM("ordinal").innerHTML = `${ordinalDisplay("H")} (${data.ord.base})=${(getHardy(data.ord.ordinal, data.ord.over, data.ord.base))}`
+}
+
+function displayOrdMarks(x){
+    let ordMark = "Oops! You shouldn't see this!"
+
+    if(data.ord.displayType === "Buchholz"){
+        ordMark = x < ordMarks.length
+            ? ordMarks[x].replace(/x/, '').replace(/y/, 'ω')
+            : (x <= ordMarksXStart[ordMarksXStart.length-1]
+                ? infiniteOrdMarks(x).replace(/x/, '').replace(/y/, 'ω')
+                : infiniteOrdMarks(ordMarksXStart[ordMarksXStart.length-1])+'x'+format(Decimal.pow(3,x-ordMarksXStart[ordMarksXStart.length-1]))
+              )
+    }
+
+    if(data.ord.displayType === "Veblen"){
+        ordMark = x < ordMarks.length
+            ? ordMarksVeblen[x].replace(/x/, '0').replace(/y/, 'φ(1)')
+            : (x <= ordMarksXStart[ordMarksXStart.length-1]
+                ? infiniteOrdMarksVeblen(x).replace(/x/, '0').replace(/y/, 'φ(1)')
+                : infiniteOrdMarksVeblen(ordMarksXStart[ordMarksXStart.length-1])+'x'+format(Decimal.pow(3,x-ordMarksXStart[ordMarksXStart.length-1]))
+              )
+    }
+
+    if(data.ord.displayType === "BMS"){
+        ordMark = x < ordMarks.length
+            ? ordMarksBMS[x]
+            : (x <= ordMarksXStart[ordMarksXStart.length-1]
+                ? infiniteOrdMarksBMS(x)
+                : infiniteOrdMarksBMS(ordMarksXStart[ordMarksXStart.length-1])+'x'+format(Decimal.pow(3,x-ordMarksXStart[ordMarksXStart.length-1]))
+              )
+    }
+
+    if(data.ord.displayType === "Y-Sequence"){
+        ordMark = x < ordMarks.length
+            ? ordMarksBMS[x]
+            : (x <= ordMarksXStart[ordMarksXStart.length-1]
+                ? infiniteOrdMarksBMS(x)
+                : infiniteOrdMarksBMS(ordMarksXStart[ordMarksXStart.length-1])
+              )
+        let n = ordMark.split(')(').length
+        ordMark = BMS2RowToYSeq(ordMark, n)
+        if (x > ordMarksXStart[ordMarksXStart.length-1]) ordMark = ordMark+'x'+format(Decimal.pow(3,x-ordMarksXStart[ordMarksXStart.length-1]))
+    }
+
+    return gwaifyOrdinal(ordMark)
+}
+
+function displayBoostReq(n = data.boost.times){
+    if (n < 33) return ordinalDisplay('', boostReq(n), data.ord.over, data.ord.base, ((data.ord.displayType === "BMS") || (data.ord.displayType === "Y-Sequence")) ? Math.max(data.ord.trim, 3) : 3)
+    return displayOrdMarks(n + 7)
+    if (n < ordMarks.length - 7) return ordMarks[n+7].replace(/x/, '').replace(/y/, 'ω')
+    if (n <= ordMarksXStart[ordMarksXStart.length-1] - 7) return infiniteOrdMarks(n+7).replace(/x/, '').replace(/y/, 'ω')
+    return infiniteOrdMarks(ordMarksXStart[ordMarksXStart.length-1])+'x'+format(Decimal.pow(3,n-ordMarksXStart[ordMarksXStart.length-1]+7))
 }

--- a/src/ordinal/ordinalDisplay.js
+++ b/src/ordinal/ordinalDisplay.js
@@ -1,28 +1,28 @@
 // The entry point for Ordinal Display
-function ordinalDisplay(type='', ord=data.ord.ordinal, over=data.ord.over, base=data.ord.base, trim=data.ord.trim, d=true) {
+function ordinalDisplay(type='', ord=data.ord.ordinal, over=data.ord.over, base=data.ord.base, trim=data.ord.trim, d=true, forcePsi=false) {
     let ordinal = "Oops! You shouldn't see this!"
 
     if(data.ord.displayType === "Buchholz"){
         ordinal = d
-            ? displayOrd(ord, Math.floor(over), base, trim)
+            ? displayOrd(ord, Math.floor(over), base, trim, forcePsi)
             : displayInfiniteOrd(ord, Math.floor(over), base, trim)
     }
 
     if(data.ord.displayType === "Veblen"){
         ordinal = d
-            ? displayVeblenOrd(ord, Math.floor(over), base, trim)
+            ? displayVeblenOrd(ord, Math.floor(over), base, trim, forcePsi)
             : displayInfiniteVeblenOrd(ord, Math.floor(over), base, trim)
     }
 
     if(data.ord.displayType === "BMS"){
         ordinal = d
-            ? displayBMSOrd(ord, Math.floor(over), base, trim)
+            ? displayBMSOrd(ord, Math.floor(over), base, trim, 0, true, forcePsi)
             : displayInfiniteBMSOrd(ord, Math.floor(over), base, trim)
     }
 
     if(data.ord.displayType === "Y-Sequence"){
         ordinal = d
-            ? displayYSeqOrd(ord, Math.floor(over), base, trim)
+            ? displayYSeqOrd(ord, Math.floor(over), base, trim, 0, true, forcePsi)
             : displayInfiniteYSeqOrd(ord, Math.floor(over), base, trim)
     }
 
@@ -104,7 +104,7 @@ function displayOrdMarks(x){
 }
 
 function displayBoostReq(n = data.boost.times){
-    if (n < 33) return ordinalDisplay('', boostReq(n), data.ord.over, data.ord.base, ((data.ord.displayType === "BMS") || (data.ord.displayType === "Y-Sequence")) ? Math.max(data.ord.trim, 3) : 3)
+    if (n < 33) return ordinalDisplay('', boostReq(n), data.ord.over, data.ord.base, ((data.ord.displayType === "BMS") || (data.ord.displayType === "Y-Sequence")) ? Math.max(data.ord.trim, 3) : 3, true, true)
     return displayOrdMarks(n + 7)
     if (n < ordMarks.length - 7) return ordMarks[n+7].replace(/x/, '').replace(/y/, 'ω')
     if (n <= ordMarksXStart[ordMarksXStart.length-1] - 7) return infiniteOrdMarks(n+7).replace(/x/, '').replace(/y/, 'ω')


### PR DESCRIPTION
- remove extra semicolons from gwas (no more :gwa:; on hierarchies displays)
- fix Hardy value display issues for all ordinal ranges (no more NaN for pre-psi ordinals + psi ordinals now always show correctly) + extend the values for psi ordinals above Number.MAX_VALUE (including future ones)
- fix ordinal display for factor boost requirements (no more rounding errors / missing ωs)
- make y-sequence display be trimmed to correct length (trim instead of trim+1) for psi ordinals + make sure edge cases are handled correctly + remove unused functions