### PR TITLE
fix baselessness crash due to Hardy value calculation issues at ExpantaNum+ ranges

### DIFF
--- a/src/collapse/baseless.js
+++ b/src/collapse/baseless.js
@@ -103,8 +103,6 @@ const anRebuyableData = [
 ]
 
 function baselessControl(){
-    data.sToggles[13] = false    
-
     if(!data.baseless.tutorial) createAlert('Welcome!', 'This popup will not be shown again!\nYou cannot respec Booster Upgrades while in this Realm. However, Dynamic Factor is unlocked immediately and the Max All AutoBuyer works all the time! I\'d recommend checking the Dynamic Factor tab, there are some things there that only exist in this realm.', 'Thanks?')
     const gain = data.baseless.baseless ? alephNullGain() : 0
 

--- a/src/ordinal/hardy.js
+++ b/src/ordinal/hardy.js
@@ -636,7 +636,7 @@ function getHardy(ord = data.ord.ordinal, over = data.ord.over, base = data.ord.
     ord = Decimal.floor(ord);
     let hardyValue = "Infinity";
     hardyValue = format(calculateHardy(ord, over, base));
-    if (hardyValue === "Infinity") {
+    if (hardyValue === "Infinity" && !data.baseless.baseless) {
         hardyValue = EN_format(hardy(ord, base, over));
         if (hardyValue === "Infinity") hardyValue = bigHardy(ord, base, over);
     }

--- a/src/ordinal/ordinalDisplay.js
+++ b/src/ordinal/ordinalDisplay.js
@@ -42,7 +42,11 @@ function changeTrim(x){
 
 // Updates the Ordinal's HTML
 function updateOrdHTML(){
-    if(!data.sToggles[13] && (data.ord.isPsi || calculateSimpleHardy().gte(Number.MAX_VALUE) || data.baseless.baseless)) {
+    let baselessCutoff = false;
+    if (data.baseless.baseless) {
+        if (format(calculateHardy(data.ord.ordinal, data.ord.over, data.ord.base)) === "Infinity") baselessCutoff = true; // disable Hardy value for baselessness once entering ExpantaNum range (due to library performance issues that will eventually freeze/crash the game)
+    }
+    if((!data.sToggles[13] && (data.ord.isPsi || calculateSimpleHardy().gte(Number.MAX_VALUE))) || baselessCutoff) {
         if(data.ord.color){
             let date = Date.now()/100
             return DOM("ordinal").innerHTML = `${colorWrap(ordinalDisplay("H"), HSL(date))} ${colorWrap(`(${data.ord.base})`, HSL(date))}`


### PR DESCRIPTION
disable Hardy value for ExpantaNum+ range on baselessness (as the issue cannot be fully rectified for high enough ordinal values) + re-enable it for unaffected lower ordinal ranges