### PR TITLE
Fix hierarchy buyables

### DIFF
--- a/src/boosters/hierarchies.js
+++ b/src/boosters/hierarchies.js
@@ -170,14 +170,16 @@ function getHBBuyableCost(i){
 function getMaxHBBuyableLevel(i){
     if(i === 2 || i === 5) return Decimal.max(Decimal.floor(Decimal.log10(data.incrementy.amt.plus(1)).sub(12)), data.hierarchies.rebuyableAmt[i])
     if(i < 2){
-        if(data.hierarchies.ords[0].ord.gte(4**4**4)) return D(getHBuyableCap())
-        let num = Decimal.max(Decimal.floor(Decimal.log(data.hierarchies.ords[0].ord.plus(1), hierarchyData[0].base())), 0)
-        return Decimal.min(getHBuyableCap(), Decimal.max(numberFromOrdinal(makeGenericOrd(num, 0, hierarchyData[0].base()), 10), data.hierarchies.rebuyableAmt[i]))
+        if(data.hierarchies.ords[0].ord.gte(Decimal.tetrate(hierarchyData[0].base(), 3)) && D(getHBuyableCap()).lte(1e10)) return D(getHBuyableCap())
+        let num = Decimal.max(Decimal.floor(effectiveFGH().log10()), 0)
+        if (num.lt(16) && effectiveFGH().lt(Decimal.pow(10,num).add(num.sub(1)))) num = num.sub(1)
+        return Decimal.min(getHBuyableCap(), Decimal.max(num, data.hierarchies.rebuyableAmt[i]))
     }
     if(i > 2 && i < 5){
-        if(data.hierarchies.ords[1].ord.gte(4**4**4)) return D(getHBuyableCap())
-        let num = Decimal.max(Decimal.floor(Decimal.log(data.hierarchies.ords[1].ord.plus(1), hierarchyData[1].base())), 0)
-        return Decimal.min(getHBuyableCap(), Decimal.max(numberFromOrdinal(makeGenericOrd(num, 0, hierarchyData[1].base()), 10), data.hierarchies.rebuyableAmt[i]))
+        if(data.hierarchies.ords[1].ord.gte(Decimal.tetrate(hierarchyData[1].base(), 3)) && D(getHBuyableCap()).lte(1e10)) return D(getHBuyableCap())
+        let num = Decimal.max(Decimal.floor(effectiveSGH().log10()), 0)
+        if (num.lt(16) && effectiveFGH().lt(Decimal.pow(10,num).add(num.sub(1)))) num = num.sub(1)
+        return Decimal.min(getHBuyableCap(), Decimal.max(num, data.hierarchies.rebuyableAmt[i]))
     }
     return D(10)
 }

--- a/src/boosters/hierarchies.js
+++ b/src/boosters/hierarchies.js
@@ -178,7 +178,7 @@ function getMaxHBBuyableLevel(i){
     if(i > 2 && i < 5){
         if(data.hierarchies.ords[1].ord.gte(Decimal.tetrate(hierarchyData[1].base(), 3)) && D(getHBuyableCap()).lte(1e10)) return D(getHBuyableCap())
         let num = Decimal.max(Decimal.floor(effectiveSGH().log10()), 0)
-        if (num.lt(16) && effectiveFGH().lt(Decimal.pow(10,num).add(num.sub(1)))) num = num.sub(1)
+        if (num.lt(16) && effectiveSGH().lt(Decimal.pow(10,num).add(num.sub(1)))) num = num.sub(1)
         return Decimal.min(getHBuyableCap(), Decimal.max(num, data.hierarchies.rebuyableAmt[i]))
     }
     return D(10)

--- a/src/ordinal/hardy.js
+++ b/src/ordinal/hardy.js
@@ -643,7 +643,7 @@ let useExpantaNum = () => data.sToggles[14]
 // Get the Hardy Value for Display
 function getHardy(ord = data.ord.ordinal, over = data.ord.over, base = data.ord.base, isPsi = data.ord.isPsi) {
     if (isPsi) return psiHardy(ord, base);
-    if(calculateSimpleHardy().lt(Number.MAX_VALUE)) return format(Decimal.floor(calculateSimpleHardy()))
+    if(calculateSimpleHardy().lt(Number.MAX_VALUE)) return format(Decimal.floor(calculateSimpleHardy().plus(1e-10)))
     ord = Decimal.floor(ord);
     let hardyValue = "Infinity";
     hardyValue = format(calculateHardy(ord, over, base));


### PR DESCRIPTION
fix getMaxHBBuyableLevel() by using already existing base conversion method (calcOrdPoints in effectiveFGH / effectiveSGH) instead of parsing ordinal display (numberFromOrdinal of makeGenericOrd)
also fix one-off Hardy value errors due to rounding error at certain values