### PR TITLE
Fix challenge 5 effect not working with one booster upgrade

### DIFF
--- a/src/boosters/challenges.js
+++ b/src/boosters/challenges.js
@@ -127,7 +127,7 @@ function decrementyGain() {
 }
 
 function getC5Effect(){
-    let m = 0
-    for (let i = 0; i < data.boost.hasBUP.length; i++) if(data.boost.hasBUP[i]) ++m
-    return Math.max(m, 1)
+    let boosterUpgradesNum = 0 // Could be replaced with "const boosterUpgradesNum = data.boost.hasBUP.filter(hasUpgrade => hasUpgrade === true).length"
+    for (let i = 0; i < data.boost.hasBUP.length; i++) if (data.boost.hasBUP[i]) ++boosterUpgradesNum // This line could be removed if the variable above is replaced
+    return boosterUpgradesNum + 1
 }


### PR DESCRIPTION
I spotted a bug in Challenge 5 while I was playing this game. Each booster upgrade is supposed to multiply Dynamic Gain and Cap by 5 but the first booster upgrade didn't count. I dug into the code and found out that the issue lies within `return Math.max(m, 1)`. The Math.max function returns the highest number that was supplied into the function. When `m = 1`, m evaluates to `Math.max(1, 1)`, which then equals to 1, which is not the intended result. The solution is simply to replace `return Math.max(m, 1)` with `return m + 1`.

I have also renamed the variable `m` to `boosterUpgradesNum` which makes more sense for future code maintainers that are trying to understand how the game works.